### PR TITLE
compat version was bumped forward unnecessarily

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.4
 Colors
-Compat 0.9.0
+Compat 0.8.0
 DataStructures
 Iterators 0.1.5
 JSON


### PR DESCRIPTION
as pointed out by @tkelman, v0.8.0 of Compat already has `unsafe_wrap`