### PR TITLE
remove duplicate compat requirement

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,2 +1,1 @@
 Cairo
-Compat v0.9.0


### PR DESCRIPTION
compat is already required by top-level REQUIRE so this is unnecessary.