### PR TITLE
drop julia 0.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: julia
 os:
-    - osx
     - linux
 sudo: required
 dist: trusty
 julia:
-    - 0.4
     - 0.5
     - nightly
 notifications:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Compose!
 
-[![][docs-latest-img]][docs-latest-url][![][pkg-0.4-img]][pkg-0.4-url] [![][pkg-0.5-img]][pkg-0.5-url][![][travis-img]][travis-url]
+[![][docs-latest-img]][docs-latest-url][![][pkg-0.5-img]][pkg-0.5-url] [![][pkg-0.6-img]][pkg-0.6-url][![][travis-img]][travis-url]
 
 Compose is a vector graphics library for Julia.
 It forms the basis for the statistical graphics system
@@ -24,10 +24,10 @@ consistent and powerful means of building vector graphics.
 [docs-latest-img]: https://img.shields.io/badge/docs-latest-blue.svg
 [docs-latest-url]: https://giovineitalia.github.io/Compose.jl/latest
 
-[pkg-0.4-img]: http://pkg.julialang.org/badges/Compose_0.4.svg
-[pkg-0.4-url]: http://pkg.julialang.org/?pkg=Compose
 [pkg-0.5-img]: http://pkg.julialang.org/badges/Compose_0.5.svg
 [pkg-0.5-url]: http://pkg.julialang.org/?pkg=Compose
+[pkg-0.6-img]: http://pkg.julialang.org/badges/Compose_0.6.svg
+[pkg-0.6-url]: http://pkg.julialang.org/?pkg=Compose
 
 [travis-img]: http://img.shields.io/travis/GiovineItalia/Compose.jl.svg
 [travis-url]: https://travis-ci.org/GiovineItalia/Compose.jl

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,4 +1,4 @@
-julia 0.4
+julia 0.5
 Colors
 Compat 0.8.0
 DataStructures


### PR DESCRIPTION
our dependencies are starting to drop support for 0.4 so we might as well
too. also drops testing on macOS because those builds keep timing out.