### PR TITLE
finish port to julia 0.6

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.5
 Colors
-Compat 0.8.0
+Compat 0.19.0
 DataStructures
 Iterators 0.1.5
 JSON

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -49,7 +49,7 @@ function isinstalled(pkg, ge=v"0.0.0-")
 end
 
 
-abstract Backend
+@compat abstract type Backend end
 
 
 """
@@ -71,7 +71,7 @@ include("measure.jl")
 include("list.jl")
 
 # Every graphic in Compose consists of a tree.
-abstract ComposeNode
+@compat abstract type ComposeNode end
 
 # Used to mark null child pointers
 immutable NullNode <: ComposeNode end

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -223,25 +223,6 @@ try
     end
 end
 
-
-import Base.Multimedia: @try_display, xdisplayable
-
-function display(p::Context)
-    displays = Base.Multimedia.displays
-    for i = length(displays):-1:1
-        m = default_mime()
-        if xdisplayable(displays[i], m, p)
-             @try_display return display(displays[i], m, p)
-        end
-
-        if xdisplayable(displays[i], p)
-            @try_display return display(displays[i], p)
-        end
-    end
-    invoke(display, Tuple{Any}, p)
-end
-
-
 function pad_outer(c::Context,
                    left_padding::MeasureOrNumber,
                    right_padding::MeasureOrNumber,

--- a/src/batch.jl
+++ b/src/batch.jl
@@ -69,7 +69,7 @@ function batch{T <: CirclePrimitive}(form::Form{T})
     end
 
     prim = CirclePrimitive((0mm, 0mm), r)
-    offsets = Array(AbsoluteVec2, n)
+    offsets = Array{AbsoluteVec2}(n)
     for i in 1:n
         offsets[i] = form.primitives[i].center
     end
@@ -212,7 +212,7 @@ function optimize_batching(ctx::Context)
 
         if !haskey(grouped_forms, h)
             grouped_forms[h] = Form[similar(form) for form in forms]
-            group_prop = Array(Property, length(properties))
+            group_prop = Array{Property}(length(properties))
             for j in 1:length(properties)
                 group_prop[j] = Property([properties[j].primitives[i]])
             end
@@ -234,6 +234,3 @@ function optimize_batching(ctx::Context)
 
     return ctx
 end
-
-
-

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -7,14 +7,14 @@ using Cairo: CairoContext, CairoSurface, CairoARGBSurface,
              CairoEPSSurface, CairoPDFSurface, CairoSVGSurface,
              CairoImageSurface
 
-abstract ImageBackend
-abstract PNGBackend <: ImageBackend
+@compat abstract type ImageBackend end
+@compat abstract type PNGBackend <: ImageBackend end
 
-abstract VectorImageBackend <: ImageBackend
-abstract SVGBackend <: VectorImageBackend
-abstract PDFBackend <: VectorImageBackend
-abstract PSBackend  <: VectorImageBackend
-abstract CairoBackend <: VectorImageBackend
+@compat abstract type VectorImageBackend <: ImageBackend end
+@compat abstract type SVGBackend <: VectorImageBackend end
+@compat abstract type PDFBackend <: VectorImageBackend end
+@compat abstract type PSBackend  <: VectorImageBackend end
+@compat abstract type CairoBackend <: VectorImageBackend end
 
 type ImagePropertyState
     stroke::RGBA{Float64}
@@ -89,7 +89,7 @@ type Image{B <: ImageBackend} <: Backend
     last_ctrl1_point::Nullable{AbsoluteVec2}
     last_ctrl2_point::Nullable{AbsoluteVec2}
 
-    function Image(surface::CairoSurface, ctx::CairoContext, out::IO)
+    @compat function Image{B}(surface::CairoSurface, ctx::CairoContext, out::IO) where {B}
         img = new()
         img.out = out
         img.width = 0
@@ -124,18 +124,18 @@ type Image{B <: ImageBackend} <: Backend
         img
     end
 
-    function Image(surface::CairoSurface, ctx::CairoContext)
+    @compat function Image{B}(surface::CairoSurface, ctx::CairoContext) where {B}
         Image{B}(surface, ctx, IOBuffer())
     end
 
-    Image(surface::CairoSurface) = Image{B}(surface, CairoContext(surface))
+    @compat Image{B}(surface::CairoSurface) where {B} = Image{B}(surface, CairoContext(surface))
 
 
-    function Image(out::IO,
-                   width::MeasureOrNumber,
-                   height::MeasureOrNumber,
-                   emit_on_finish::Bool=true;
-                   dpi = (B == PNGBackend ? 96 : 72))
+    @compat function Image{B}(out::IO,
+                              width::MeasureOrNumber,
+                              height::MeasureOrNumber,
+                              emit_on_finish::Bool=true;
+                              dpi = (B == PNGBackend ? 96 : 72)) where {B}
 
         width = size_measure(width)
         height = size_measure(height)
@@ -158,30 +158,30 @@ type Image{B <: ImageBackend} <: Backend
         img
     end
 
-    function Image(filename::AbstractString,
-                   width::MeasureOrNumber,
-                   height::MeasureOrNumber;
-                   dpi = (B == PNGBackend ? 96 : 72))
+    @compat function Image{B}(filename::AbstractString,
+                              width::MeasureOrNumber,
+                              height::MeasureOrNumber;
+                              dpi = (B == PNGBackend ? 96 : 72)) where {B}
         img = Image{B}(open(filename, "w"), width, height, dpi = dpi)
         img.ownedfile = true
         img.filename = filename
         img
     end
 
-    function Image(width::MeasureOrNumber,
-                   height::MeasureOrNumber,
-                   emit_on_finish::Bool=true;
-                   dpi = (B == PNGBackend ? 96 : 72))
+    @compat function Image{B}(width::MeasureOrNumber,
+                              height::MeasureOrNumber,
+                              emit_on_finish::Bool=true;
+                              dpi = (B == PNGBackend ? 96 : 72)) where {B}
         img = Image{B}(IOBuffer(), width, height, emit_on_finish, dpi = dpi)
         img
     end
 end
 
 
-typealias PNG Image{PNGBackend}
-typealias PDF Image{PDFBackend}
-typealias PS  Image{PSBackend}
-typealias CAIROSURFACE  Image{CairoBackend}
+const PNG = Image{PNGBackend}
+const PDF = Image{PDFBackend}
+const PS =  Image{PSBackend}
+const CAIROSURFACE =  Image{CairoBackend}
 
 
 function canbatch(img::Image)

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -110,8 +110,8 @@ type Image{B <: ImageBackend} <: Backend
         img.font = default_font_family
         img.clip = Nullable{ClipPrimitive}()
 
-        img.state_stack = Array(ImagePropertyState, 0)
-        img.property_stack = Array(ImagePropertyFrame, 0)
+        img.state_stack = Array{ImagePropertyState}(0)
+        img.property_stack = Array{ImagePropertyFrame}(0)
         img.vector_properties = Dict{Type, Nullable{Property}}()
         img.owns_surface = false
         img.ownedfile = false
@@ -337,7 +337,7 @@ function push_property_frame(img::Image, properties::Vector{Property})
 
     frame = ImagePropertyFrame()
     applied_properties = Set{Type}()
-    scalar_properties = Array(Property, 0)
+    scalar_properties = Array{Property}(0)
     for property in properties
         if isscalar(property) && !(typeof(property) in applied_properties)
             push!(scalar_properties, property)
@@ -568,8 +568,8 @@ end
 # --------------
 
 function current_point(img::Image)
-    x = Array(Float64, 1)
-    y = Array(Float64, 1)
+    x = Array{Float64}(1)
+    y = Array{Float64}(1)
     ccall((:cairo_get_current_point, Cairo._jl_libcairo), Void,
           (Ptr{Void}, Ptr{Float64}, Ptr{Float64}), img.ctx.ptr, x, y)
     return ((x[1] / img.ppmm)*mm, (x[2] / img.ppmm)*mm)

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -89,8 +89,8 @@ type Image{B <: ImageBackend} <: Backend
     last_ctrl1_point::Nullable{AbsoluteVec2}
     last_ctrl2_point::Nullable{AbsoluteVec2}
 
-    @compat function Image{B}(surface::CairoSurface, ctx::CairoContext, out::IO) where {B}
-        img = new()
+    @compat function (::Type{Image{B}}){B}(surface::CairoSurface, ctx::CairoContext, out::IO)
+        img = new{B}()
         img.out = out
         img.width = 0
         img.height = 0
@@ -124,18 +124,18 @@ type Image{B <: ImageBackend} <: Backend
         img
     end
 
-    @compat function Image{B}(surface::CairoSurface, ctx::CairoContext) where {B}
+    @compat function (::Type{Image{B}}){B}(surface::CairoSurface, ctx::CairoContext)
         Image{B}(surface, ctx, IOBuffer())
     end
 
-    @compat Image{B}(surface::CairoSurface) where {B} = Image{B}(surface, CairoContext(surface))
+    @compat (::Type{Image{B}}){B}(surface::CairoSurface) = Image{B}(surface, CairoContext(surface))
 
 
-    @compat function Image{B}(out::IO,
+    @compat function (::Type{Image{B}}){B}(out::IO,
                               width::MeasureOrNumber,
                               height::MeasureOrNumber,
                               emit_on_finish::Bool=true;
-                              dpi = (B == PNGBackend ? 96 : 72)) where {B}
+                              dpi = (B == PNGBackend ? 96 : 72))
 
         width = size_measure(width)
         height = size_measure(height)
@@ -158,20 +158,20 @@ type Image{B <: ImageBackend} <: Backend
         img
     end
 
-    @compat function Image{B}(filename::AbstractString,
+    @compat function (::Type{Image{B}}){B}(filename::AbstractString,
                               width::MeasureOrNumber,
                               height::MeasureOrNumber;
-                              dpi = (B == PNGBackend ? 96 : 72)) where {B}
+                              dpi = (B == PNGBackend ? 96 : 72))
         img = Image{B}(open(filename, "w"), width, height, dpi = dpi)
         img.ownedfile = true
         img.filename = filename
         img
     end
 
-    @compat function Image{B}(width::MeasureOrNumber,
+    @compat function (::Type{Image{B}}){B}(width::MeasureOrNumber,
                               height::MeasureOrNumber,
                               emit_on_finish::Bool=true;
-                              dpi = (B == PNGBackend ? 96 : 72)) where {B}
+                              dpi = (B == PNGBackend ? 96 : 72))
         img = Image{B}(IOBuffer(), width, height, emit_on_finish, dpi = dpi)
         img
     end

--- a/src/container.jl
+++ b/src/container.jl
@@ -1,7 +1,7 @@
 
 # A container is a node in the tree that can have Forms, Properties, or other
 # Containers as children.
-abstract Container <: ComposeNode
+@compat abstract type Container <: ComposeNode end
 
 
 # The basic Container which defines a coordinate transform for its children.
@@ -280,7 +280,7 @@ end
 # absolute size, or it is one many possible layout that we want to decide
 # between before rendering. A ContainerPromise lets us defer computing a subtree
 # until the graphic is actually being rendered.
-abstract ContainerPromise <: Container
+@compat abstract type ContainerPromise <: Container end
 
 
 # This information is passed to a container promise at drawtime.

--- a/src/container.jl
+++ b/src/container.jl
@@ -514,7 +514,7 @@ function drawpart(backend::Backend, container::Container,
     has_properties = false
     if !isa(ctx.property_children, ListNull) || ctx.clip
         has_properties = true
-        properties = Array(Property, 0)
+        properties = Array{Property}(0)
 
         child = ctx.property_children
         while !isa(child, ListNull)
@@ -571,7 +571,7 @@ function drawpart(backend::Backend, container::Container,
     end
 
     if ordered_children
-        container_children = Array((@compat Tuple{Int, Int, Container}), 0)
+        container_children = Array{@compat Tuple{Int, Int, Container}}(0)
         child = ctx.container_children
         while !isa(child, ListNull)
             push!(container_children,

--- a/src/container.jl
+++ b/src/container.jl
@@ -651,7 +651,7 @@ function introspect(root::Context)
             compose!(fig,
                 polygon([(0.5cx - figsize/2, 0.5cy - figsize/2),
                          (0.5cx + figsize/2, 0.5cy - figsize/2),
-                         (0.5, 0.5cy + figsize/2)]),
+                         (0.5cx, 0.5cy + figsize/2)]),
                 fill(LCHab(68, 74, 29)))
         else
             error("Unknown node type $(typeof(node))")

--- a/src/fontfallback.jl
+++ b/src/fontfallback.jl
@@ -210,5 +210,5 @@ function pango_to_svg(text::AbstractString)
     if open_tag
         write(output, "</tspan>")
     end
-    takebuf_string(output)
+    String(take!(output))
 end

--- a/src/fontfallback.jl
+++ b/src/fontfallback.jl
@@ -127,7 +127,7 @@ function text_extents(font_family::AbstractString, size::Measure, texts::Abstrac
     glyphwidths = glyphsizes[font_family]["widths"]
     fontsize = size/pt
 
-    extents = Array((@compat Tuple{Measure, Measure}), length(texts))
+    extents = Array{@compat Tuple{Measure, Measure}}(length(texts))
     for (i, text) in enumerate(texts)
         chunkwidths = Float64[]
         textheight = 0.0

--- a/src/form.jl
+++ b/src/form.jl
@@ -9,7 +9,7 @@ immutable Form{P <: FormPrimitive} <: ComposeNode
     primitives::Vector{P}
     tag::Symbol
 
-    @compat function Form{P}(prim, tag::Symbol=empty_tag) where {P}
+    @compat function Form{P}(prim, tag::Symbol=empty_tag) where {P <: FormPrimitive}
         new(prim, tag)
     end
 end
@@ -54,7 +54,7 @@ const PolygonPrimitive = SimplePolygonPrimitive
 
 
 function polygon()
-    return Polygon([PolygonPrimitive(Vec[])])
+    return Form([PolygonPrimitive(Vec[])])
 end
 
 """
@@ -73,7 +73,7 @@ function polygon{T <: XYTupleOrVec}(points::AbstractArray{T}, tag=empty_tag)
     end
     VecType = Tuple{XM, YM}
 
-    return Polygon([PolygonPrimitive(VecType[(x_measure(point[1]), y_measure(point[2]))
+    return Form([PolygonPrimitive(VecType[(x_measure(point[1]), y_measure(point[2]))
                     for point in points])], tag)
 end
 

--- a/src/form.jl
+++ b/src/form.jl
@@ -1,7 +1,7 @@
 
 # A form is something that ends up as geometry in the graphic.
 
-abstract FormPrimitive
+@compat abstract type FormPrimitive end
 
 const empty_tag = Symbol("")
 
@@ -9,7 +9,7 @@ immutable Form{P <: FormPrimitive} <: ComposeNode
     primitives::Vector{P}
     tag::Symbol
 
-    function Form(prim, tag::Symbol=empty_tag)
+    @compat function Form{P}(prim, tag::Symbol=empty_tag) where {P}
         new(prim, tag)
     end
 end
@@ -47,10 +47,10 @@ immutable SimplePolygonPrimitive{P <: Vec} <: FormPrimitive
     points::Vector{P}
 end
 
-typealias SimplePolygon{P<:SimplePolygonPrimitive} Form{P}
+const SimplePolygon{P<:SimplePolygonPrimitive} = Form{P}
 
-typealias Polygon SimplePolygon
-typealias PolygonPrimitive SimplePolygonPrimitive
+const Polygon = SimplePolygon
+const PolygonPrimitive = SimplePolygonPrimitive
 
 
 function polygon()
@@ -118,7 +118,7 @@ immutable ComplexPolygonPrimitive{P <: Vec} <: FormPrimitive
     rings::Vector{Vector{P}}
 end
 
-typealias ComplexPolygon{P<:ComplexPolygonPrimitive} Form{P}
+const ComplexPolygon{P<:ComplexPolygonPrimitive} = Form{P}
 
 
 function complexpolygon()
@@ -172,7 +172,7 @@ immutable RectanglePrimitive{P <: Vec, M1 <: Measure, M2 <: Measure} <: FormPrim
     height::M2
 end
 
-typealias Rectangle{P<:RectanglePrimitive} Form{P}
+const Rectangle{P<:RectanglePrimitive} = Form{P}
 
 """
     rectangle()
@@ -267,7 +267,7 @@ function CirclePrimitive(x, y, r)
 end
 
 
-typealias Circle{P<:CirclePrimitive} Form{P}
+const Circle{P<:CirclePrimitive} = Form{P}
 
 """
     circle()
@@ -332,7 +332,7 @@ immutable EllipsePrimitive{P1 <: Vec, P2 <: Vec, P3 <: Vec} <: FormPrimitive
     y_point::P3
 end
 
-typealias Ellipse{P<:EllipsePrimitive} Form{P}
+const Ellipse{P<:EllipsePrimitive} = Form{P}
 
 
 function ellipse()
@@ -390,7 +390,7 @@ form_string(::Ellipse) = "E"
 # Text
 # ----
 
-abstract HAlignment
+@compat abstract type HAlignment end
 immutable HLeft   <: HAlignment end
 immutable HCenter <: HAlignment end
 immutable HRight  <: HAlignment end
@@ -399,7 +399,7 @@ const hleft   = HLeft()
 const hcenter = HCenter()
 const hright  = HRight()
 
-abstract VAlignment
+@compat abstract type VAlignment end
 immutable VTop    <: VAlignment end
 immutable VCenter <: VAlignment end
 immutable VBottom <: VAlignment end
@@ -420,7 +420,7 @@ immutable TextPrimitive{P <: Vec, R <: Rotation} <: FormPrimitive
     rot::R
 end
 
-typealias Text{P<:TextPrimitive} Form{P}
+const Text{P<:TextPrimitive} = Form{P}
 
 
 
@@ -514,7 +514,7 @@ immutable LinePrimitive{P <: Vec} <: FormPrimitive
     points::Vector{P}
 end
 
-typealias Line{P<:LinePrimitive} Form{P}
+const Line{P<:LinePrimitive} = Form{P}
 
 
 function line()
@@ -577,7 +577,7 @@ immutable CurvePrimitive{P1 <: Vec, P2 <: Vec, P3 <: Vec, P4 <: Vec} <: FormPrim
     anchor1::P4
 end
 
-typealias Curve{P<:CurvePrimitive} Form{P}
+const Curve{P<:CurvePrimitive} = Form{P}
 
 
 function curve(anchor0::XYTupleOrVec, ctrl0::XYTupleOrVec,
@@ -621,7 +621,7 @@ immutable BitmapPrimitive{P <: Vec, XM <: Measure, YM <: Measure} <: FormPrimiti
     height::YM
 end
 
-typealias Bitmap{P<:BitmapPrimitive} Form{P}
+const Bitmap{P<:BitmapPrimitive} = Form{P}
 
 
 function bitmap(mime::AbstractString, data::Vector{UInt8}, x0, y0, width, height, tag=empty_tag)
@@ -663,7 +663,7 @@ form_string(::Bitmap) = "B"
 
 # An implementation of the SVG path mini-language.
 
-abstract PathOp
+@compat abstract type PathOp end
 
 immutable MoveAbsPathOp <: PathOp
     to::Vec
@@ -1158,7 +1158,7 @@ immutable PathPrimitive <: FormPrimitive
     ops::Vector{PathOp}
 end
 
-typealias Path Form{PathPrimitive}
+const Path = Form{PathPrimitive}
 
 
 function path(tokens::AbstractArray, tag=empty_tag)

--- a/src/form.jl
+++ b/src/form.jl
@@ -9,9 +9,7 @@ immutable Form{P <: FormPrimitive} <: ComposeNode
     primitives::Vector{P}
     tag::Symbol
 
-    @compat function Form{P}(prim, tag::Symbol=empty_tag) where {P <: FormPrimitive}
-        new(prim, tag)
-    end
+    @compat (::Type{Form{P}}){P}(prim, tag::Symbol=empty_tag) = new{P}(prim, tag)
 end
 
 function Form{P<:FormPrimitive}(primitives::Vector{P}, tag::Symbol=empty_tag)
@@ -47,7 +45,7 @@ immutable SimplePolygonPrimitive{P <: Vec} <: FormPrimitive
     points::Vector{P}
 end
 
-const SimplePolygon{P<:SimplePolygonPrimitive} = Form{P}
+@compat const SimplePolygon{P<:SimplePolygonPrimitive} = Form{P}
 
 const Polygon = SimplePolygon
 const PolygonPrimitive = SimplePolygonPrimitive
@@ -118,7 +116,7 @@ immutable ComplexPolygonPrimitive{P <: Vec} <: FormPrimitive
     rings::Vector{Vector{P}}
 end
 
-const ComplexPolygon{P<:ComplexPolygonPrimitive} = Form{P}
+@compat const ComplexPolygon{P<:ComplexPolygonPrimitive} = Form{P}
 
 
 function complexpolygon()
@@ -172,7 +170,7 @@ immutable RectanglePrimitive{P <: Vec, M1 <: Measure, M2 <: Measure} <: FormPrim
     height::M2
 end
 
-const Rectangle{P<:RectanglePrimitive} = Form{P}
+@compat const Rectangle{P<:RectanglePrimitive} = Form{P}
 
 """
     rectangle()
@@ -267,7 +265,7 @@ function CirclePrimitive(x, y, r)
 end
 
 
-const Circle{P<:CirclePrimitive} = Form{P}
+@compat const Circle{P<:CirclePrimitive} = Form{P}
 
 """
     circle()
@@ -326,13 +324,13 @@ form_string(::Circle) = "C"
 # -------
 
 
-immutable EllipsePrimitive{P1 <: Vec, P2 <: Vec, P3 <: Vec} <: FormPrimitive
+immutable EllipsePrimitive{P1<:Vec, P2<:Vec, P3<:Vec} <: FormPrimitive
     center::P1
     x_point::P2
     y_point::P3
 end
 
-const Ellipse{P<:EllipsePrimitive} = Form{P}
+@compat const Ellipse{P<:EllipsePrimitive} = Form{P}
 
 
 function ellipse()
@@ -409,7 +407,7 @@ const vcenter = VCenter()
 const vbottom = VBottom()
 
 
-immutable TextPrimitive{P <: Vec, R <: Rotation} <: FormPrimitive
+immutable TextPrimitive{P<:Vec, R<:Rotation} <: FormPrimitive
     position::P
     value::AbstractString
     halign::HAlignment
@@ -420,7 +418,7 @@ immutable TextPrimitive{P <: Vec, R <: Rotation} <: FormPrimitive
     rot::R
 end
 
-const Text{P<:TextPrimitive} = Form{P}
+@compat const Text{P<:TextPrimitive} = Form{P}
 
 
 
@@ -510,11 +508,11 @@ form_string(::Text) = "T"
 # Line
 # ----
 
-immutable LinePrimitive{P <: Vec} <: FormPrimitive
+immutable LinePrimitive{P<:Vec} <: FormPrimitive
     points::Vector{P}
 end
 
-const Line{P<:LinePrimitive} = Form{P}
+@compat const Line{P<:LinePrimitive} = Form{P}
 
 
 function line()
@@ -570,22 +568,23 @@ form_string(::Line) = "L"
 # Curve
 # -----
 
-immutable CurvePrimitive{P1 <: Vec, P2 <: Vec, P3 <: Vec, P4 <: Vec} <: FormPrimitive
+immutable CurvePrimitive{P1<:Vec, P2<:Vec, P3<:Vec, P4<:Vec} <: FormPrimitive
     anchor0::P1
     ctrl0::P2
     ctrl1::P3
     anchor1::P4
 end
 
-const Curve{P<:CurvePrimitive} = Form{P}
+@compat const Curve{P<:CurvePrimitive} = Form{P}
 
 
 function curve(anchor0::XYTupleOrVec, ctrl0::XYTupleOrVec,
                ctrl1::XYTupleOrVec, anchor1::XYTupleOrVec, tag=empty_tag)
-    return Curve([CurvePrimitive((x_measure(anchor0[1]), y_measure(anchor0[2])),
+    prim = CurvePrimitive((x_measure(anchor0[1]), y_measure(anchor0[2])),
                                  (x_measure(ctrl0[1]), y_measure(ctrl0[2])),
                                  (x_measure(ctrl1[1]), y_measure(ctrl1[2])),
-                                 (x_measure(anchor1[1]), y_measure(anchor1[2])))], tag)
+                                 (x_measure(anchor1[1]), y_measure(anchor1[2])))
+    return Curve{typeof(prim)}([prim], tag)
 end
 
 
@@ -621,7 +620,7 @@ immutable BitmapPrimitive{P <: Vec, XM <: Measure, YM <: Measure} <: FormPrimiti
     height::YM
 end
 
-const Bitmap{P<:BitmapPrimitive} = Form{P}
+@compat const Bitmap{P<:BitmapPrimitive} = Form{P}
 
 
 function bitmap(mime::AbstractString, data::Vector{UInt8}, x0, y0, width, height, tag=empty_tag)

--- a/src/form.jl
+++ b/src/form.jl
@@ -83,7 +83,7 @@ function polygon(point_arrays::AbstractArray, tag=empty_tag)
     VecType = XM == YM == Any ? Vec : Tuple{XM, YM}
     PrimType = XM == YM == Any ? PolygonPrimitive : PolygonPrimitive{VecType}
 
-    polyprims = Array(PrimType, length(point_arrays))
+    polyprims = Array{PrimType}(length(point_arrays))
     for (i, point_array) in enumerate(point_arrays)
         polyprims[i] = PrimType(VecType[(x_measure(point[1]), y_measure(point[2]))
                                         for point in point_array])
@@ -536,7 +536,7 @@ function line(point_arrays::AbstractArray, tag=empty_tag)
     VecType = XM == YM == Any ? Vec2 : Tuple{XM, YM}
     PrimType = XM == YM == Any ? LinePrimitive : LinePrimitive{VecType}
 
-    lineprims = Array(PrimType, length(point_arrays))
+    lineprims = Array{PrimType}(length(point_arrays))
     for (i, point_array) in enumerate(point_arrays)
         p = PrimType(VecType[(x_measure(point[1]), y_measure(point[2]))
                              for point in point_array])

--- a/src/list.jl
+++ b/src/list.jl
@@ -1,7 +1,7 @@
 
 # Basic list
 
-abstract List{T}
+@compat abstract type List{T} end
 
 immutable ListNull{T} <: List{T} end
 
@@ -80,6 +80,3 @@ function show{T}(io::IO, a::List{T})
     end
     print(io, "])")
 end
-
-
-

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -17,8 +17,8 @@ const cy = Length{:cy}
 const assumed_ppmm = 3.78 # equivalent to 96 DPI
 const px = mm/assumed_ppmm
 
-typealias XYTupleOrVec Union{NTuple{2}, Vec}
-typealias MeasureOrNumber Union{Measure, Number}
+const XYTupleOrVec = Union{NTuple{2}, Vec}
+const MeasureOrNumber = Union{Measure, Number}
 
 
 # Scaling w and h components
@@ -142,8 +142,8 @@ immutable UnitBox{S, T, U, V}
     toppad::AbsoluteLength
     bottompad::AbsoluteLength
 
-    function UnitBox(x0::S, y0::T, width::U, height::V;
-                     leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm)
+    @compat function UnitBox{S, T, U, V}(x0::S, y0::T, width::U, height::V;
+                                 leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm) where {S, T, U, V}
         return new(x0, y0, width, height, leftpad, rightpad, toppad, bottompad)
     end
 end
@@ -173,7 +173,7 @@ function UnitBox()
 end
 
 
-typealias NullUnitBox Nullable{UnitBox}
+const NullUnitBox = Nullable{UnitBox}
 
 
 # copy with substitution
@@ -238,7 +238,7 @@ end
 
 # Transform matrix in absolute coordinates
 
-abstract Transform
+@compat abstract type Transform end
 
 
 immutable IdentityTransform <: Transform
@@ -284,7 +284,7 @@ immutable Rotation{P <: Vec}
     offset::P
 
     # copy constructor
-    function Rotation(theta::Float64, offset::P)
+    @compat function Rotation{P}(theta::Float64, offset::P) where {P}
         new(theta, offset)
     end
 end

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -17,8 +17,8 @@ const cy = Length{:cy}
 const assumed_ppmm = 3.78 # equivalent to 96 DPI
 const px = mm/assumed_ppmm
 
-const XYTupleOrVec = Union{NTuple{2}, Vec}
 const MeasureOrNumber = Union{Measure, Number}
+const XYTupleOrVec = Union{Tuple{MeasureOrNumber,MeasureOrNumber}, Vec}
 
 
 # Scaling w and h components
@@ -142,9 +142,9 @@ immutable UnitBox{S, T, U, V}
     toppad::AbsoluteLength
     bottompad::AbsoluteLength
 
-    @compat function UnitBox{S, T, U, V}(x0::S, y0::T, width::U, height::V;
-                                 leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm) where {S, T, U, V}
-        return new(x0, y0, width, height, leftpad, rightpad, toppad, bottompad)
+    @compat function (::Type{UnitBox{S,T,U,V}}){S,T,U,V}(x0::S, y0::T, width::U, height::V;
+                                 leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm)
+        return new{S,T,U,V}(x0, y0, width, height, leftpad, rightpad, toppad, bottompad)
     end
 end
 
@@ -284,8 +284,8 @@ immutable Rotation{P <: Vec}
     offset::P
 
     # copy constructor
-    @compat function Rotation{P}(theta::Float64, offset::P) where {P}
-        new(theta, offset)
+    @compat function (::Type{Rotation{P}}){P}(theta::Float64, offset::P)
+        new{P}(theta, offset)
     end
 end
 

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -98,7 +98,7 @@ macro makeform(args...)
         prim1 = $(constructor)
         T = typeof(prim1)
 
-        primitives = Array(T, n)
+        primitives = Array{T}(n)
         primitives[1] = prim1
         for i in 2:n
             $(iter_ex)
@@ -123,7 +123,7 @@ macro makeprimitives(args)
 
         push!(maxlen_ex.args, quote
             if isempty($(arr))
-                primitives = Array($(T), 0)
+                primitives = Array{$(T)}(0)
                 @goto done
             end end)
         push!(maxlen_ex.args, quote n = max(n, length($(arr))) end)
@@ -134,7 +134,7 @@ macro makeprimitives(args)
 
     quote
         $(maxlen_ex)
-        primitives = Array($(T), n)
+        primitives = Array{$(T)}(n)
         for i in 1:n
             $(iter_ex)
             primitives[i] = $(constructor)
@@ -246,4 +246,3 @@ end
     *(a::AbstractFloat, b::Dates.Millisecond) = Dates.Millisecond(round(Integer, (a * b.value)))
     *(a::Dates.Millisecond, b::AbstractFloat) = b * a
 #end
-

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -95,7 +95,7 @@ function pango_text_extents(pangolayout::PangoLayout, text::AbstractString)
           Void, (Ptr{Void}, Ptr{UInt8}, Int32),
           pangolayout.layout, textarray, length(textarray))
 
-    extents = Array(Int32, 4)
+    extents = Array{Int32}(4)
     ccall((:pango_layout_get_extents, libpango),
           Void, (Ptr{Void}, Ptr{Int32}, Ptr{Int32}),
           pangolayout.layout, extents, C_NULL)
@@ -324,8 +324,8 @@ function unpack_pango_attr_list(ptr::Ptr{Void})
                                      attr_it, eval(attr_name))
 
     attr_it_range = () -> begin
-        start_idx = Array(Int32, 1)
-        end_idx = Array(Int32, 1)
+        start_idx = Array{Int32}(1)
+        end_idx = Array{Int32}(1)
         ccall((:pango_attr_iterator_range, libpango),
               Void, (Ptr{Void}, Ptr{Int32}, Ptr{Int32}),
               attr_it, start_idx, end_idx)
@@ -333,7 +333,7 @@ function unpack_pango_attr_list(ptr::Ptr{Void})
     end
 
 
-    attrs = Array((@compat Tuple{Int, PangoAttr}), 0)
+    attrs = Array{@compat Tuple{Int, PangoAttr}}(0)
 
     while attr_it_next() != 0
 

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -98,7 +98,7 @@ type PGF <: Backend
         img.indentation = 0
         img.out = out
         img.color_set = Set{Color}([colorant"black"])
-        img.property_stack = Array(PGFPropertyFrame, 0)
+        img.property_stack = Array{PGFPropertyFrame}(0)
         img.vector_properties = Dict{Type, Nullable{Property}}()
         # img.clippaths = Dict{ClipPrimitive, String}()
         img.visible = true
@@ -521,7 +521,7 @@ function push_property_frame(img::PGF, properties::Vector{Property})
 
     frame = PGFPropertyFrame()
     applied_properties = Set{Type}()
-    scalar_properties = Array(Property, 0)
+    scalar_properties = Array{Property}(0)
     for property in properties
         if !isrepeatable(property) && (typeof(property) in applied_properties)
             continue

--- a/src/property.jl
+++ b/src/property.jl
@@ -1,4 +1,4 @@
-abstract PropertyPrimitive
+@compat abstract type PropertyPrimitive end
 
 # Meaningless isless function used to sort in optimize_batching
 function Base.isless{T <: PropertyPrimitive}(a::T, b::T)
@@ -63,7 +63,7 @@ immutable StrokePrimitive <: PropertyPrimitive
 	color::RGBA{Float64}
 end
 
-typealias Stroke Property{StrokePrimitive}
+const Stroke = Property{StrokePrimitive}
 
 
 function stroke(c::(@compat Void))
@@ -89,7 +89,7 @@ immutable FillPrimitive <: PropertyPrimitive
 	color::RGBA{Float64}
 end
 
-typealias Fill Property{FillPrimitive}
+const Fill = Property{FillPrimitive}
 
 
 function fill(c::(@compat Void))
@@ -116,7 +116,7 @@ immutable StrokeDashPrimitive <: PropertyPrimitive
     value::Vector{Measure}
 end
 
-typealias StrokeDash Property{StrokeDashPrimitive}
+const StrokeDash = Property{StrokeDashPrimitive}
 
 
 function strokedash(values::AbstractArray)
@@ -141,7 +141,7 @@ prop_string(::StrokeDash) = "sd"
 # -------------
 
 
-abstract LineCap
+@compat abstract type LineCap end
 immutable LineCapButt <: LineCap end
 immutable LineCapSquare <: LineCap end
 immutable LineCapRound <: LineCap end
@@ -159,7 +159,7 @@ immutable StrokeLineCapPrimitive <: PropertyPrimitive
     end
 end
 
-typealias StrokeLineCap Property{StrokeLineCapPrimitive}
+const StrokeLineCap = Property{StrokeLineCapPrimitive}
 
 
 function strokelinecap(value::@compat(Union{LineCap, Type{LineCap}}))
@@ -176,7 +176,7 @@ prop_string(::StrokeLineCap) = "slc"
 # StrokeLineJoin
 # --------------
 
-abstract LineJoin
+@compat abstract type LineJoin end
 immutable LineJoinMiter <: LineJoin end
 immutable LineJoinRound <: LineJoin end
 immutable LineJoinBevel <: LineJoin end
@@ -194,7 +194,7 @@ immutable StrokeLineJoinPrimitive <: PropertyPrimitive
     end
 end
 
-typealias StrokeLineJoin Property{StrokeLineJoinPrimitive}
+const StrokeLineJoin = Property{StrokeLineJoinPrimitive}
 
 
 function strokelinejoin(value::@compat(Union{LineJoin, Type{LineJoin}}))
@@ -219,7 +219,7 @@ immutable LineWidthPrimitive <: PropertyPrimitive
     end
 end
 
-typealias LineWidth Property{LineWidthPrimitive}
+const LineWidth = Property{LineWidthPrimitive}
 
 
 function linewidth(value::@compat(Union{Measure, Number}))
@@ -246,7 +246,7 @@ immutable VisiblePrimitive <: PropertyPrimitive
     value::Bool
 end
 
-typealias Visible Property{VisiblePrimitive}
+const Visible = Property{VisiblePrimitive}
 
 
 function visible(value::Bool)
@@ -276,7 +276,7 @@ immutable FillOpacityPrimitive <: PropertyPrimitive
     end
 end
 
-typealias FillOpacity Property{FillOpacityPrimitive}
+const FillOpacity = Property{FillOpacityPrimitive}
 
 
 function fillopacity(value::Float64)
@@ -306,7 +306,7 @@ immutable StrokeOpacityPrimitive <: PropertyPrimitive
     end
 end
 
-typealias StrokeOpacity Property{StrokeOpacityPrimitive}
+const StrokeOpacity = Property{StrokeOpacityPrimitive}
 
 
 function strokeopacity(value::Float64)
@@ -327,7 +327,7 @@ immutable ClipPrimitive{P <: Vec} <: PropertyPrimitive
     points::Vector{P}
 end
 
-typealias Clip Property{ClipPrimitive}
+const Clip = Property{ClipPrimitive}
 
 
 function clip()
@@ -379,7 +379,7 @@ immutable FontPrimitive <: PropertyPrimitive
     family::AbstractString
 end
 
-typealias Font Property{FontPrimitive}
+const Font = Property{FontPrimitive}
 
 
 function font(family::AbstractString)
@@ -414,7 +414,7 @@ immutable FontSizePrimitive <: PropertyPrimitive
     end
 end
 
-typealias FontSize Property{FontSizePrimitive}
+const FontSize = Property{FontSizePrimitive}
 
 
 function fontsize(value::@compat(Union{Number, Measure}))
@@ -441,7 +441,7 @@ immutable SVGIDPrimitive <: PropertyPrimitive
     value::AbstractString
 end
 
-typealias SVGID Property{SVGIDPrimitive}
+const SVGID = Property{SVGIDPrimitive}
 
 
 function svgid(value::AbstractString)
@@ -473,7 +473,7 @@ immutable SVGClassPrimitive <: PropertyPrimitive
     value::Compat.UTF8String
 end
 
-typealias SVGClass Property{SVGClassPrimitive}
+const SVGClass = Property{SVGClassPrimitive}
 
 
 function svgclass(value::AbstractString)
@@ -511,7 +511,7 @@ immutable SVGAttributePrimitive <: PropertyPrimitive
     value::Compat.ASCIIString
 end
 
-typealias SVGAttribute Property{SVGAttributePrimitive}
+const SVGAttribute = Property{SVGAttributePrimitive}
 
 
 function svgattribute(attribute::AbstractString, value)
@@ -554,7 +554,7 @@ immutable JSIncludePrimitive <: PropertyPrimitive
     jsmodule::@compat(Union{(@compat Void), @compat Tuple{AbstractString, AbstractString}})
 end
 
-typealias JSInclude Property{JSIncludePrimitive}
+const JSInclude = Property{JSIncludePrimitive}
 
 
 function jsinclude(value::AbstractString, module_name=nothing)
@@ -574,7 +574,7 @@ immutable JSCallPrimitive <: PropertyPrimitive
     args::Vector{Measure}
 end
 
-typealias JSCall Property{JSCallPrimitive}
+const JSCall = Property{JSCallPrimitive}
 
 
 function jscall(code::AbstractString, arg::Vector{Measure}=Measure[])

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -59,7 +59,7 @@ function svg_print_float(io::IO, x::AbstractFloat)
     end
 end
 
-let a = Array(UInt8, 20)
+let a = Array{UInt8}(20)
 global svg_print_uint
 function svg_print_uint(io::IO, x::Unsigned, width = 0, drop = false)
     n = length(a)

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -108,7 +108,7 @@ function svg_newlines(input::AbstractString, x::Float64)
         write(output, "</tspan>")
     end
 
-    return takebuf_string(output)
+    return String(take!(output))
 end
 
 
@@ -240,10 +240,10 @@ type SVG <: Backend
         img.out = out
         img.cached_out = nothing
         img.indentation = 0
-        img.property_stack = Array(SVGPropertyFrame, 0)
+        img.property_stack = Array{SVGPropertyFrame}(0)
         img.vector_properties = Dict{Type, @compat(Union{(@compat Void), Property})}()
         img.clippaths = Dict{ClipPrimitive, Compat.ASCIIString}()
-        img.batches = Array(Tuple{FormPrimitive, Compat.ASCIIString}, 0)
+        img.batches = Array{Tuple{FormPrimitive, Compat.ASCIIString}}(0)
         img.embobj = Set{AbstractString}()
         img.finished = false
         img.emit_on_finish = emit_on_finish
@@ -251,7 +251,7 @@ type SVG <: Backend
         img.has_current_id = false
         img.id_count = 0
         img.jsheader = AbstractString[]
-        img.jsmodules = Array((@compat Tuple{AbstractString, AbstractString}), 1)
+        img.jsmodules = Array{@compat Tuple{AbstractString, AbstractString}}(1)
         img.jsmodules[1] = ("Snap.svg", "Snap")
         img.scripts = AbstractString[]
         img.withjs = jsmode != :none
@@ -904,7 +904,7 @@ function draw(img::SVG, prim::TextPrimitive, idx::Int)
     svg_print_float(img.out, prim.position[2].value)
     print(img.out, '"')
 
-    if is(prim.halign, hcenter)
+    if prim.halign === hcenter
         print(img.out, " text-anchor=\"middle\"")
     elseif is(prim.halign, hright)
         print(img.out, " text-anchor=\"end\"")
@@ -913,7 +913,7 @@ function draw(img::SVG, prim::TextPrimitive, idx::Int)
     # NOTE: "dominant-baseline" is the correct way to vertically center text
     # in SVG, but implementations are pretty inconsistent (chrome in particular
     # does a really bad job). We fake it by shifting by some reasonable amount.
-    if is(prim.valign, vcenter)
+    if prim.valign === vcenter
         print(img.out, " dy=\"0.35em\"")
         #print(img.out, " style=\"dominant-baseline:central\"")
     elseif is(prim.valign, vtop)
@@ -1220,7 +1220,7 @@ function push_property_frame(img::SVG, properties::Vector{Property})
 
     frame = SVGPropertyFrame()
     applied_properties = Set{Type}()
-    scalar_properties = Array(Property, 0)
+    scalar_properties = Array{Property}(0)
     for property in properties
         if !isrepeatable(property) && (typeof(property) in applied_properties)
             continue

--- a/src/table-jump.jl
+++ b/src/table-jump.jl
@@ -29,7 +29,7 @@ function realize(tbl::Table, drawctx::ParentDrawContext)
         end
     end
 
-    penalties = Array(Float64, length(c_indexes))
+    penalties = Array{Float64}(length(c_indexes))
     for (l, (i, j, k)) in enumerate(c_indexes)
         penalties[l] = tbl.children[i, j][k].penalty
     end

--- a/src/table.jl
+++ b/src/table.jl
@@ -57,14 +57,14 @@ type Table <: ContainerPromise
             y_prop ./= sum(filter(x -> !isnan(x), y_prop))
         end
 
-        tbl = new(Array(Vector{Context}, (m, n)),
+        tbl = new(Array{Vector{Context}}((m, n)),
                   x_focus, y_focus,
                   x_prop, y_prop,
                   aspect_ratio,
                   fixed_configs,
                   units, order, withjs, withoutjs)
         for i in 1:m, j in 1:n
-            tbl.children[i, j] = Array(Context, 0)
+            tbl.children[i, j] = Array{Context}(0)
         end
         return tbl
     end
@@ -150,12 +150,12 @@ function realize_brute_force(tbl::Table, drawctx::ParentDrawContext)
     # which is basically "size needed" - "size available".
     minbadness = Inf
 
-    focused_col_widths = Array(Float64, length(tbl.x_focus))
-    focused_row_heights = Array(Float64, length(tbl.y_focus))
+    focused_col_widths = Array{Float64}(length(tbl.x_focus))
+    focused_row_heights = Array{Float64}(length(tbl.y_focus))
 
     # minimum sizes for each column and row
-    minrowheights = Array(Float64, m)
-    mincolwidths = Array(Float64, n)
+    minrowheights = Array{Float64}(m)
+    mincolwidths = Array{Float64}(n)
 
     # convert tbl.fixed_configs to linear indexing
     fixed_configs = Any[

--- a/test/compare_examples.jl
+++ b/test/compare_examples.jl
@@ -9,7 +9,7 @@ for output in readdir(cachedout)
     if same
         lsame = Bool[cached[i] == genned[i] for i = 1:n]
         if !all(lsame)
-            for idx in find(!lsame)
+            for idx in find(lsame.==false)
                 # Don't worry about lines that are due to
                 # Creator/Producer (e.g., Cairo versions)
                 if !isempty(search(cached[idx], creator_producer))

--- a/test/immerse.jl
+++ b/test/immerse.jl
@@ -13,8 +13,8 @@ draw(be, ctx)
 @test be.coords[:rect][2] == Compose.UnitBox{Float64,Float64,Float64,Float64}(0.0,0.0,1.0,1.0)
 
 ### Finding tagged objects
-typealias ContainersWithChildren Union{Context,Compose.Table}
-typealias Iterables Union{ContainersWithChildren, AbstractArray}
+const ContainersWithChildren = Union{Context,Compose.Table}
+const Iterables = Union{ContainersWithChildren, AbstractArray}
 
 iterable(ctx::ContainersWithChildren) = ctx.children
 iterable(a::AbstractArray) = a
@@ -74,4 +74,4 @@ end
 
 box, units, transform = be.coords[:rect]
 xd, yd = absolute_to_data(0.5mm, 0.5mm, transform, units, box)
-@test_approx_eq_eps xd 0.1417 0.0001
+@test isapprox(xd,0.1417; atol=0.0001)

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -8,7 +8,7 @@ tomato_bisque =
 
 io = IOBuffer()
 showcompact(io, tomato_bisque)
-str = takebuf_string(io)
+str = String(take!(io))
 @test str == "Context(Context(R,f),Context(C,f))"
 
 # Tagging


### PR DESCRIPTION
this simply adds one more commit to https://github.com/GiovineItalia/Compose.jl/pull/239 which removes the remaining dep warns.  one can now cleanly `using Compose` on julia 0.5 and 0.6.

while tests pass on 0.6, they currently don't for 0.5, neither for the master branch of Compose nor this PR:

```
julia> Pkg.test("Compose")
INFO: Computing test dependencies for Compose...
INFO: No packages to install, update or remove
INFO: Testing Compose
Test Failed
  Expression: ((text_extents(font_family,8pt,"test test"))[1])[2] * 2 == ((text_extents(font_family,8pt,"test\ntest"))[1])[2]
   Evaluated: 3.7758246527777772mm == 5.206917317708333mm
```

but that is a separate issue...