### PR TITLE
Fix one more instance of hash with hardcoded UInt64

### DIFF
--- a/src/batch.jl
+++ b/src/batch.jl
@@ -202,10 +202,10 @@ function optimize_batching(ctx::Context)
     # step 2: split primitives into groups on the cross product of property
     # primives
     n = length(forms[1].primitives)
-    grouped_forms = Dict{UInt64, Vector{Form}}()
-    grouped_properties = Dict{UInt64, Vector{Property}}()
+    grouped_forms = Dict{UInt, Vector{Form}}()
+    grouped_properties = Dict{UInt, Vector{Property}}()
     for i in 1:n
-        h = UInt64(0)
+        h = UInt(0)
         for property in properties
             h = hash(property.primitives[i], h)
         end


### PR DESCRIPTION
The standard hash seems to be yield UInt. If used with UInt64, this does not work on a 32 bit platform.

This is another case along "misc fixes for 32bit systems #243".