### PR TITLE
New divisor function for Dates

### DIFF
--- a/src/misc.jl
+++ b/src/misc.jl
@@ -215,6 +215,11 @@ if !method_exists(/, (Dates.Day, Dates.Millisecond))
     /(a::Dates.Day, b::Dates.Millisecond) = convert(Dates.Millisecond, a) / b
 end
 
+if !method_exists(/, (Dates.Millisecond, Dates.Day))
+    /(a::Dates.Millisecond, b::Dates.Day) = a / convert(Dates.Millisecond, b) 
+end
+
+
 for T in [Dates.Hour, Dates.Minute, Dates.Second, Dates.Millisecond]
     if !method_exists(-, (Dates.Date, T))
         @eval begin


### PR DESCRIPTION
In Gadfly GiovineItalia/Gadfly.jl#784, using `Coord.cartesian(xmin=Date(2014,03,01), xmax=Date(2016,02,01))` currently throws an error not in `Gadfly`, but in `Compose`. This is because `Compose` is a missing a function that allows `Dates.Millisecond` to be divided by `Dates.Day`. This PR adds that function to `Compose`. I've provided an example in GiovineItalia/Gadfly.jl#784 showing that this works with `Date` or `DateTime` objects. 