### PR TITLE
downgrade Compat require to 0.18

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.5
 Colors
-Compat 0.19.0
+Compat 0.18.0
 DataStructures
 Iterators 0.1.5
 JSON


### PR DESCRIPTION
per a [comment](https://github.com/JuliaLang/METADATA.jl/pull/8810) when tagging the last release