### PR TITLE
fixup - fix one more 0.6 dep warn

### DIFF
--- a/examples/dashedlines.jl
+++ b/examples/dashedlines.jl
@@ -29,5 +29,8 @@ patterns = Array[
 
 c = draw_lines(patterns)
 
-img = PDF("dash.pdf", 4inch, 4(sqrt(3)/2)inch)
-draw(img, compose(c, stroke(colorant"black"), linewidth(1mm)))
+imgs = [PDF("dash.pdf", 4inch, 4(sqrt(3)/2)inch),
+        PGF("dash.pdf", 4inch, 4(sqrt(3)/2)inch)]
+for img = imgs
+  draw(img, compose(c, stroke(colorant"black"), linewidth(1mm)))
+end

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -272,7 +272,7 @@ function push_property!(props_str, img::PGF, property::StrokeDashPrimitive)
         return
     else
         push!(props_str, string("dash pattern=", join(map( v -> join(v, " "),
-                zip(Base.Iterators.cycle(["on", "off"]),
+                zip(Compat.Iterators.cycle(["on", "off"]),
                     map(v -> string(svg_fmt_float(v.value), "mm"), property.value)) )," ")))
     end
 end


### PR DESCRIPTION
accidentally used Base.Iterators instead of Compat.Iterators.  tests didn't catch it because none of them use the PGF backend.  made the change and added a test.