### PR TITLE
add default width and height to backends

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -46,11 +46,21 @@ draw(SVG("tomato.svg", 4cm, 4cm), composition)
 nothing # hide
 ```
 
+![](tomato.svg)
+
 The last line renders the composition to specificied backend, here the SVG
 backend. This can also be written like
 `composition |> SVG("tomato.svg", 4cm, 4cm)`.
+Alternatively, if multiple compositions of the same size are to be
+generated, this can be abbreviated even further to
 
-![](tomato.svg)
+```
+set_default_plot_size(4cm, 4cm)
+composition |> SVG("tomato.svg")
+composition2 |> SVG("celery.svg")
+composition3 |> SVG("rutabaga.svg")  # etc...
+```
+
 
 ## The compose function accepts S-expressions
 
@@ -72,7 +82,7 @@ parenthesis or brackets.
 composition = compose(context(),
         (context(), circle(), fill("bisque")),
         (context(), rectangle(), fill("tomato")))
-composition |> SVG("tomato_bisque.svg", 4cm, 4cm)
+composition |> SVG("tomato_bisque.svg")
 nothing # hide
 ```
 
@@ -99,8 +109,8 @@ introspect(tomato_bisque)
 This is a little cryptic, but you can use this limited edition decoder ring:
 
 ```julia
-using Compose, Colors, Measures # hide
-set_default_graphic_size(6cm, 4cm) # hide
+using Compose, Colors, Measures
+set_default_graphic_size(6cm, 4cm)
 
 figsize = 6mm
 t = table(3, 2, 1:3, 2:2, y_prop=[1.0, 1.0, 1.0])
@@ -129,13 +139,14 @@ different coordinate systems.
 
 ```@setup 3
 using Compose
+set_default_graphic_size(4cm, 4cm)
 ```
 
 ```@example 3
 composition = compose(context(), fill("tomato"),
         (context(0.0, 0.0, 0.5, 0.5), circle()),
         (context(0.5, 0.5, 0.5, 0.5), circle()))
-composition |> SVG("tomatos.svg", 4cm, 4cm)
+composition |> SVG("tomatos.svg")
 nothing # hide
 ```
 
@@ -157,7 +168,7 @@ composition = compose(context(),
         (context(),
          polygon([(1, 1), (0.5, 1), (0.5, 0)]),
          fill("bisque")))
-composition |> SVG("tomato_bisque_triangle.svg", 4cm, 4cm)
+composition |> SVG("tomato_bisque_triangle.svg")
 nothing # hide
 ```
 
@@ -202,13 +213,14 @@ second form can succinctly create many circles (using the [Colors](https://githu
 
 ```@setup 4
 using Compose, Colors
+set_default_graphic_size(4cm, 4cm)
 ```
 
 ```@example 4
 composition = compose(context(),
         circle([0.25, 0.5, 0.75], [0.25, 0.5, 0.75], [0.1, 0.1, 0.1]),
         fill(LCHab(92, 10, 77)))
-composition |> SVG("circles.svg", 4cm, 4cm)
+composition |> SVG("circles.svg")
 nothing # hide
 ```
 
@@ -222,7 +234,7 @@ specifying the radius just once.
 composition = compose(context(),
         circle([0.25, 0.5, 0.75], [0.25, 0.5, 0.75], [0.1]),
         fill(LCHab(92, 10, 77)))
-composition |> SVG("cycled_circles.svg", 4cm, 4cm)
+composition |> SVG("cycled_circles.svg")
 nothing # hide
 ```
 
@@ -236,7 +248,7 @@ colors to each circle.
 circles_fill_vectorized = compose(context(),
         circle([0.25, 0.5, 0.75], [0.25, 0.5, 0.75], [0.1]),
         fill([LCHab(92, 10, 77), LCHab(68, 74, 192), LCHab(78, 84, 29)]))
-circles_fill_vectorized |> SVG("circles_fill_vectorized.svg", 4cm, 4cm)
+circles_fill_vectorized |> SVG("circles_fill_vectorized.svg")
 nothing # hide
 ```
 

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -151,7 +151,8 @@ end
         Image{B}(surface, CairoContext(surface))
 
 function (::Type{Image{B}}){B<:ImageBackend}(out::IO,
-            width::MeasureOrNumber, height::MeasureOrNumber,
+            width::MeasureOrNumber=default_graphic_width,
+            height::MeasureOrNumber=default_graphic_height,
             emit_on_finish::Bool=true;
             dpi = (B==PNGBackend ? 96 : 72),
             kwargs...)
@@ -173,11 +174,13 @@ function (::Type{Image{B}}){B<:ImageBackend}(out::IO,
 end
 
 (::Type{Image{B}}){B<:ImageBackend}(filename::AbstractString,
-            width::MeasureOrNumber, height::MeasureOrNumber;
+            width::MeasureOrNumber=default_graphic_width,
+            height::MeasureOrNumber=default_graphic_height;
             dpi = (B==PNGBackend ? 96 : 72)) =
         Image{B}(open(filename, "w"), width, height, dpi=dpi; ownedfile=true, filename=filename)
 
-(::Type{Image{B}}){B<:ImageBackend}(width::MeasureOrNumber, height::MeasureOrNumber,
+(::Type{Image{B}}){B<:ImageBackend}(width::MeasureOrNumber=default_graphic_width,
+            height::MeasureOrNumber=default_graphic_height,
             emit_on_finish::Bool=true;
             dpi = (B==PNGBackend ? 96 : 72)) =
         Image{B}(IOBuffer(), width, height, emit_on_finish, dpi=dpi)

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -269,11 +269,13 @@ function SVG(out::IO,
 end
 
 # Write to a file.
-SVG(filename::AbstractString, width, height, jsmode::Symbol=:none) =
+SVG(filename::AbstractString, width=default_graphic_width, height=default_graphic_height,
+        jsmode::Symbol=:none) =
         SVG(open(filename, "w"), width, height, true, jsmode; ownedfile=true, filename=filename)
 
 # Write to buffer.
-SVG(width::MeasureOrNumber, height::MeasureOrNumber, emit_on_finish::Bool=true, jsmode::Symbol=:none) =
+SVG(width::MeasureOrNumber=default_graphic_width, height::MeasureOrNumber=default_graphic_height,
+        emit_on_finish::Bool=true, jsmode::Symbol=:none) =
         SVG(IOBuffer(), width, height, emit_on_finish, jsmode)
 
 canbatch(img::SVG) = true
@@ -290,12 +292,13 @@ function genid(img::SVG)
 end
 
 # Constructors that turn javascript extensions on
-SVGJS(out::IO, width, height, emit_on_finish::Bool=true; jsmode::Symbol=:embed) =
+SVGJS(out::IO, width=default_graphic_width, height=default_graphic_height,
+        emit_on_finish::Bool=true; jsmode::Symbol=:embed) =
         SVG(out, width, height, emit_on_finish, jsmode)
-SVGJS(filename::AbstractString, width, height; jsmode::Symbol=:embed) =
-        SVG(filename, width, height, jsmode)
-SVGJS(width::MeasureOrNumber, height::MeasureOrNumber,
-               emit_on_finish::Bool=true, jsmode::Symbol=:embed) =
+SVGJS(filename::AbstractString, width=default_graphic_width, height=default_graphic_height;
+        jsmode::Symbol=:embed) = SVG(filename, width, height, jsmode)
+SVGJS(width::MeasureOrNumber=default_graphic_width, height::MeasureOrNumber=default_graphic_height,
+        emit_on_finish::Bool=true, jsmode::Symbol=:embed) =
         SVG(width, height, emit_on_finish, jsmode)
 
 function writeheader(img::SVG)


### PR DESCRIPTION
`SVG(filename,width,height)` (plus it's PDF, PNG, etc friends) now has a new method `SVG(filename)` where the width and height default to `Compose.default_graphic_{width,height}`, which can be set with`set_default_graphic_size` or `Gadfly.set_default_plot_size`.

this simplifies some of my workflows, but will it break anything?