### PR TITLE
Make scalar properties override vector properties.

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -293,6 +293,7 @@ function push_property_frame(img::Image, properties::Vector{Property})
             push!(scalar_properties, property)
             push!(applied_properties, typeof(property))
             frame.has_scalar_properties = true
+            img.vector_properties[typeof(property)] = Nullable{Property}()
         elseif !isscalar(property)
             frame.vector_properties[typeof(property)] = property
             img.vector_properties[typeof(property)] = property

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -465,6 +465,7 @@ function push_property_frame(img::PGF, properties::Vector{Property})
             push!(scalar_properties, property)
             push!(applied_properties, typeof(property))
             frame.has_scalar_properties = true
+            img.vector_properties[typeof(property)] = Nullable{Property}()
         else
             frame.vector_properties[typeof(property)] = property
             img.vector_properties[typeof(property)] = property

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1126,6 +1126,7 @@ function push_property_frame(img::SVG, properties::Vector{Property})
             push!(scalar_properties, property)
             push!(applied_properties, typeof(property))
             frame.has_scalar_properties = true
+            img.vector_properties[typeof(property)] = nothing
         else
             frame.vector_properties[typeof(property)] = property
             img.vector_properties[typeof(property)] = property


### PR DESCRIPTION
This is the right way to fix https://github.com/GiovineItalia/Gadfly.jl/issues/770. 

Simple fix, but took while to track down. Currently behavior when drawing something like this
```julia
compose(context(), fill(["red", "blue"]),
    [context(), fill("green"), circle([0.25, 0.75], [0.5], [0.25])])
```
is that the scalar `fill("green")` doesn't override the vector `fill(["red", "blue"])` and it will draw a red and blue circle. That doesn't really make a lot of sense, and can cause issues with batch optimization which rewrites trees turning vector properties into scalar properties. So with this PR that code draws two green circles.

This changes the drawing behavior, I think in a pretty benign way, but this shouldn't be merged until we know what if anything this breaks.