### PR TITLE
print SVG clippaths in sorted order

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -164,7 +164,7 @@ type SVG <: Backend
     vector_properties::Dict{Type, Union{(Void), Property}}
 
     # Clip-paths that need to be defined at the end of the document.
-    clippaths::Dict{ClipPrimitive, Compat.String}
+    clippaths::OrderedDict{ClipPrimitive, Compat.String}
 
     # Batched forms to be included within <def> tags.
     batches::Vector{Tuple{FormPrimitive, Compat.String}}
@@ -226,7 +226,7 @@ function SVG(out::IO,
              indentation = 0,
              property_stack = Array{SVGPropertyFrame}(0),
              vector_properties = Dict{Type, Union{(Void), Property}}(),
-             clippaths = Dict{ClipPrimitive, Compat.String}(),
+             clippaths = OrderedDict{ClipPrimitive, Compat.String}(),
              batches = Array{Tuple{FormPrimitive, Compat.String}}(0),
              embobj = Set{AbstractString}(),
              finished = false,


### PR DESCRIPTION
does anyone know why clipPaths appear in a random order in the defs section of SVGs?  it makes regression testing in Gadfly painful.  my guess it that it's because they're stored in a Dict, and for some reason julia is iterating over them differently.  not sure at all why, or why even a Dict is necessary.  this PR fixes it, but in a not very graceful post-hoc way.  am open to suggestions, but will merge at some point if no one has any better solutions.