### PR TITLE
Drop some IterTools methods for Base.Iterators methods

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -110,7 +110,7 @@ context(x0=0.0w, y0=0.0h, width=1.0w, height=1.0h;
             ListNull{Container}(), ListNull{Form}(), ListNull{Property}(),
             order, clip, withjs, withoutjs, raster, minwidth, minheight, penalty, tag)
 
-children(ctx::Context) = chain(ctx.container_children, ctx.form_children, ctx.property_children)
+children(ctx::Context) = Iterators.flatten((ctx.container_children, ctx.form_children, ctx.property_children))
 
 # Updating context fields
 


### PR DESCRIPTION
These two _might_ get deprecated in IterTools so I want to make sure they aren't necessary. 

Note that the ordering for Base.Iterators.product is different than the ordering for IterTools.product, and there are no Compose tests which follow that path. 