### PR TITLE
Strokedash edit

### DIFF
--- a/src/property.jl
+++ b/src/property.jl
@@ -86,7 +86,7 @@ end
 const StrokeDash = Property{StrokeDashPrimitive}
 
 strokedash(values::AbstractArray) = StrokeDash([StrokeDashPrimitive(collect(Measure, values))])
-strokedash(values::AbstractArray{AbstractArray}) =
+strokedash(values::AbstractArray{<:AbstractArray}) =
         StrokeDash([StrokeDashPrimitive(collect(Measure, value)) for value in values])
 
 resolve(box::AbsoluteBox, units::UnitBox, t::Transform, primitive::StrokeDashPrimitive) =


### PR DESCRIPTION
I ran into this issue while working on Gadfly `Guide.linekey`.
In `Compose`, `strokedash(values::AbstractArray{AbstractArray})` won't work because e.g.:
```julia
Vector{Vector} <: AbstractArray{AbstractArray} # is false
```
The correct syntax is `AbstractArray{<:AbstractArray}`. So with this edit, the following now works:

```julia
using Compose, Gadfly
line_style = [:solid, :dash, :dot, :dashdot, :dashdotdot]
linestyles = Gadfly.get_stroke_vector.(line_style)
lines = [[(0.0,x),(1.0,x)] for x in linspace(0.1,0.9, 5)] 

p = compose(context(),
    (context(), Compose.line(lines), strokedash(linestyles), stroke("deepskyblue"))
)
```
![strokedash](https://user-images.githubusercontent.com/18226881/43770525-fd43731a-9a7f-11e8-925d-fc31b6a6cb9a.png)
