### PR TITLE
implement optional loading of Cairo and Fontconfig

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -1,7 +1,11 @@
 using Compat
 
 # Cairo backend for compose
-import Cairo
+if VERSION < v"0.7-"
+    import Cairo
+else
+    topimport(:Cairo)
+end
 
 using Cairo: CairoContext, CairoSurface, CairoARGBSurface,
              CairoEPSSurface, CairoPDFSurface, CairoSVGSurface,
@@ -185,9 +189,15 @@ Image{B}(width::MeasureOrNumber=default_graphic_width,
             dpi = (B==PNGBackend ? 96 : 72)) where {B<:ImageBackend} =
         Image{B}(IOBuffer(), width, height, emit_on_finish, dpi=dpi)
 
-const PNG = Image{PNGBackend}
-const PDF = Image{PDFBackend}
-const PS  = Image{PSBackend}
+PNG(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
+    Image{PNGBackend}(x, args...)
+
+PDF(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
+    Image{PDFBackend}(x, args...)
+
+PS(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
+    Image{PSBackend}(x, args...)
+
 const CAIROSURFACE = Image{CairoBackend}
 
 function (img::Image)(x)
@@ -274,9 +284,9 @@ isfinished(img::Image) = img.finished
 
 root_box(img::Image) = BoundingBox(width(img), height(img))
 
-show(io::IO, ::MIME"image/png", img::PNG) = write(io, String(take!(img.out)))
-show(io::IO, ::MIME"application/pdf", img::PDF) = write(io, String(take!(img.out)))
-show(io::IO, ::MIME"application/postscript", img::PS) = write(io, String(take!(img.out)))
+show(io::IO, ::MIME"image/png", img::Image{PNGBackend}) = write(io, String(take!(img.out)))
+show(io::IO, ::MIME"application/pdf", img::Image{PDFBackend}) = write(io, String(take!(img.out)))
+show(io::IO, ::MIME"application/postscript", img::Image{PSBackend}) = write(io, String(take!(img.out)))
 
 
 # Applying Properties

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -1,6 +1,10 @@
 # Estimation of text extents using pango.
 
-import Fontconfig
+if VERSION < v"0.7-"
+    import Fontconfig
+else
+    topimport(:Fontconfig)
+end
 
 const libpangocairo = Cairo._jl_libpangocairo
 const libpango = Cairo._jl_libpango

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1,4 +1,9 @@
 using Compat
+if VERSION < v"0.7-"
+    import Base.Random.uuid4
+else
+    import UUIDs: uuid4
+end
 
 const snapsvgjs = joinpath(dirname(@__FILE__), "..", "data", "snap.svg-min.js")
 
@@ -223,7 +228,7 @@ function SVG(out::IO,
              jsmode::Symbol=:none;
 
              cached_out = nothing,
-             id = string("img-", string(Base.Random.uuid4())[1:8]),
+             id = string("img-", string(uuid4())[1:8]),
              indentation = 0,
              property_stack = Array{SVGPropertyFrame}(0),
              vector_properties = Dict{Type, Union{Property, Nothing}}(),

--- a/test/immerse.jl
+++ b/test/immerse.jl
@@ -5,6 +5,7 @@
 using Test
 using Compose
 import Cairo
+import Measures
 
 ### The Immerse backend
 srf = Cairo.CairoImageSurface(10, 10, Cairo.FORMAT_RGB24)


### PR DESCRIPTION
This is one way to handle the optional loading issue, which would allow you to tag for v0.7. (Eventually the Pkg maintainers may sanction something official, but why wait?)  I didn't intentionally break compatibility with v0.6, but I didn't test for it either.

Note that random numbers are not consistent across Julia versions, so the tests fail as they stand; actual images were indistinguishable to this mere mortal.

You should add v0.7 to the CI matrix; there are lots of deprecations which fail on nightly but might be ok for v0.7.