### PR TITLE
Accommodate Requires for Julia v0.7

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -1,11 +1,16 @@
 using Compat
 
 # Cairo backend for compose
-import Cairo
+if VERSION < v"0.7-"
+    import Cairo
+end
+# in later versions, Requires does the import for us, but resolution is tricky
 
-using Cairo: CairoContext, CairoSurface, CairoARGBSurface,
-             CairoEPSSurface, CairoPDFSurface, CairoSVGSurface,
-             CairoImageSurface
+for name in (:CairoContext, :CairoSurface, :CairoARGBSurface, :CairoEPSSurface,
+             :CairoPDFSurface, :CairoSVGSurface, :CairoImageSurface)
+    val = getfield(Cairo,name)
+    @eval const $name = $val
+end
 
 abstract type ImageBackend end
 abstract type PNGBackend <: ImageBackend end
@@ -185,9 +190,15 @@ Image{B}(width::MeasureOrNumber=default_graphic_width,
             dpi = (B==PNGBackend ? 96 : 72)) where {B<:ImageBackend} =
         Image{B}(IOBuffer(), width, height, emit_on_finish, dpi=dpi)
 
-const PNG = Image{PNGBackend}
-const PDF = Image{PDFBackend}
-const PS  = Image{PSBackend}
+PNG(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
+    Image{PNGBackend}(x, args...)
+
+PDF(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
+    Image{PDFBackend}(x, args...)
+
+PS(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
+    Image{PSBackend}(x, args...)
+
 const CAIROSURFACE = Image{CairoBackend}
 
 function (img::Image)(x)
@@ -274,9 +285,9 @@ isfinished(img::Image) = img.finished
 
 root_box(img::Image) = BoundingBox(width(img), height(img))
 
-show(io::IO, ::MIME"image/png", img::PNG) = write(io, String(take!(img.out)))
-show(io::IO, ::MIME"application/pdf", img::PDF) = write(io, String(take!(img.out)))
-show(io::IO, ::MIME"application/postscript", img::PS) = write(io, String(take!(img.out)))
+show(io::IO, ::MIME"image/png", img::Image{PNGBackend}) = write(io, String(take!(img.out)))
+show(io::IO, ::MIME"application/pdf", img::Image{PDFBackend}) = write(io, String(take!(img.out)))
+show(io::IO, ::MIME"application/postscript", img::Image{PSBackend}) = write(io, String(take!(img.out)))
 
 
 # Applying Properties

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -1,9 +1,14 @@
 # Estimation of text extents using pango.
 
-import Fontconfig
+if VERSION < v"0.7-"
+    import Fontconfig
+end
+# In later versions, Requires does the import for us.
+# Qualified uses of Fontconfig and Cairo entities are not problematic.
 
 const libpangocairo = Cairo._jl_libpangocairo
 const libpango = Cairo._jl_libpango
+const libgobject = Cairo._jl_libgobject
 
 # Cairo text backend
 const CAIRO_FONT_TYPE_TOY = 0

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1,4 +1,9 @@
 using Compat
+if VERSION < v"0.7-"
+    import Base.Random.uuid4
+else
+    import UUIDs: uuid4
+end
 
 const snapsvgjs = joinpath(dirname(@__FILE__), "..", "data", "snap.svg-min.js")
 
@@ -223,7 +228,7 @@ function SVG(out::IO,
              jsmode::Symbol=:none;
 
              cached_out = nothing,
-             id = string("img-", string(Base.Random.uuid4())[1:8]),
+             id = string("img-", string(uuid4())[1:8]),
              indentation = 0,
              property_stack = Array{SVGPropertyFrame}(0),
              vector_properties = Dict{Type, Union{Property, Nothing}}(),

--- a/test/immerse.jl
+++ b/test/immerse.jl
@@ -5,6 +5,7 @@
 using Test
 using Compose
 import Cairo
+import Measures
 
 ### The Immerse backend
 srf = Cairo.CairoImageSurface(10, 10, Cairo.FORMAT_RGB24)


### PR DESCRIPTION
This version works if callers of PNG etc. import Cairo themselves.

Tests will fail because random number sequences have changed for v0.7 (but images seem indistinguishable).