### PR TITLE
Fixes #292

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -518,6 +518,7 @@ curve_to(img::Image, ctrl1::AbsoluteVec2, ctrl2::AbsoluteVec2, anchor::AbsoluteV
             absolute_native_units(img, anchor[2].value))
 
 close_path(img::Image) = Cairo.close_path(img.ctx)
+new_sub_path(img::Image) = Cairo.new_sub_path(img.ctx)
 
 arc(img::Image, x::Float64, y::Float64, radius::Float64, angle1::Float64, angle2::Float64) =
         Cairo.arc(img.ctx,
@@ -648,11 +649,13 @@ function draw(img::Image, prim::Compose.ComplexPolygonPrimitive)
 end
 
 function draw(img::Image, prim::CirclePrimitive)
+    new_sub_path(img)
     circle(img, prim.center, prim.radius)
     fillstroke(img)
 end
 
 function draw(img::Image, prim::EllipsePrimitive)
+    new_sub_path(img)
     cx = prim.center[1].value
     cy = prim.center[2].value
     rx = sqrt((prim.x_point[1].value - cx)^2 +
@@ -662,7 +665,7 @@ function draw(img::Image, prim::EllipsePrimitive)
     theta = atan(prim.x_point[2].value - cy,
                  prim.x_point[1].value - cx)
 
-    all(isfinite([cx, cy, rx, ry, theta])) || return
+    all(isfinite,[cx, cy, rx, ry, theta]) || return
 
     save_property_state(img)
     translate(img, cx, cy)

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -387,7 +387,7 @@ function draw(img::PGF, prim::EllipsePrimitive, idx::Int)
     theta = rad2deg(atan(prim.x_point[2].value - cy,
                          prim.x_point[1].value - cx))
 
-    all(isfinite([cx, cy, rx, ry, theta])) || return
+    all(isfinite,[cx, cy, rx, ry, theta]) || return
 
     modifiers, props = get_vector_properties(img, idx)
     write(img.buf, join(modifiers))


### PR DESCRIPTION
Fixes #292 by adding a `new_sub_path` function.

```julia
import Cairo
using Compose

img1 = compose(context(),
  (context(order=2), circle(0.5,0.5,0.15), fill("red"), stroke("black")),
  (context(order=1), text(0.2,0.2,"toto"), fill("black"))
)
img2 = compose(context(),
  (context(order=2, rotation=Rotation(-pi/8)), ellipse(0.5,0.5,0.3,0.15), fill("red"), stroke("black")),
  (context(order=1), text(0.2,0.2,"toto"), fill("black"))
)
draw(PNG(9cm,3cm), hstack(img1, img2))
```
![issue292d](https://user-images.githubusercontent.com/18226881/45252928-b7d38780-b3a1-11e8-8662-1115a83cff20.png)
