### PR TITLE
Fix method error in table.jl

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -100,8 +100,8 @@ function force_aspect_ratio!(tbl::Table,
         w = w0
         h = h0 * adj
         delta = h0 - h
-        y_solution[1:tbl.y_focus.stop] += delta/2
-        y_solution[tbl.y_focus.stop+1:end] -= delta/2
+        y_solution[1:tbl.y_focus.stop] .+= delta/2
+        y_solution[tbl.y_focus.stop+1:end] .-= delta/2
         h_solution[tbl.y_focus] *= adj
     end
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -97,3 +97,19 @@ twolines = text_extents(font_family, 8pt, "Peg\nPeg")[1]
     @test Compose.escape_tex_chars("\\") == "\\textbackslash{}"
     @test Compose.pango_to_pgf("hello\\") == "\\text{hello\\textbackslash{}}"
 end
+
+@testset "table" begin
+    @testset "force aspect ratio" begin
+        tbl = Compose.Table(1, 1, UnitRange(1,1), UnitRange(3:3), aspect_ratio=1.6);
+        x_solution = [0.0, 5.8, 11.8]
+        w_solution = [5.8, 6.0, 119.6]
+        y_solution = [0.0, 85.3]
+        h_solution = [85.3, 4.7]
+        x0, w0 = copy(x_solution), copy(w_solution)
+        Compose.force_aspect_ratio!(tbl, x_solution, y_solution, w_solution, h_solution)
+        @test x_solution == x0
+        @test w_solution == w0
+        @test y_solution ≈ [5.275, 80.025]
+        @test h_solution == [74.75, 4.7]
+    end
+end


### PR DESCRIPTION
Fixes problem with the following plot on Julia v1.0.0.  Otherwise I get
`ERROR: MethodError: no method matching +(::Array{Float64,1}, ::Float64)`
```
plot(
    layer(x=[-2.5, 2.5, 2.25, 2.5, 2.25],y=[0, 0, 0.15, 0 ,-0.15],
        Geom.line(preserve_order=true)),
        Coord.cartesian(aspect_ratio=MathConstants.golden)
 )
```