### PR TITLE
fix stackoverflow in table printing and add tests

### DIFF
--- a/src/table.jl
+++ b/src/table.jl
@@ -365,6 +365,6 @@ function show(io::IO, t::Table)
             println(io)
         end
     else
-        print(io, t)
+        invoke(show, Tuple{IO, Any}, io, t)
     end
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -2,14 +2,38 @@ using Test, Random
 using Colors
 
 # showcompact
-tomato_bisque = compose(context(),
-            (context(), circle(), fill(colorant"bisque")),
-            (context(), rectangle(), fill(colorant"tomato")))
+@testset "printing" begin
+    @testset "context" begin
+        io = IOBuffer()
+        tomato_bisque = compose(context(),
+                    (context(), circle(), fill(colorant"bisque")),
+                    (context(), rectangle(), fill(colorant"tomato")))
 
-io = IOBuffer()
-show(IOContext(io, :compact=>true), tomato_bisque)
-str = String(take!(io))
-@test str == "Context(Context(R,f),Context(C,f))"
+        # compact printing
+        show(IOContext(io, :compact=>true), tomato_bisque)
+        str = String(take!(io))
+        @test str == "Context(Context(R,f),Context(C,f))"
+
+        # full printing
+        show(io, context())
+        str = String(take!(io))
+        @test str == "Context(Measures.BoundingBox{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}},Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}}((0.0w, 0.0h), (1.0w, 1.0h)), nothing, nothing, nothing, List([]), List([]), List([]), 0, false, false, false, false, nothing, nothing, 0.0, Symbol(\"\"))"
+    end
+    @testset "table" begin
+        t = Compose.Table(1, 1, UnitRange(1,1), UnitRange(3:3), aspect_ratio=1.6)
+        io = IOBuffer()
+
+        # compact printing
+        show(IOContext(io, :compact=>true), t)
+        str = String(take!(io))
+        @test str == "1x1 Table:\n  Context[]\n"
+
+        # full printing
+        show(io, t)
+        str = String(take!(io))
+        @test str == "Compose.Table(Array{Context,1}[[]], 3:3, 1:1, nothing, nothing, 1.6, Any[], nothing, 0, false, false)"
+    end
+end
 
 # Tagging
 points(xa, ya) = [(x, y) for (x, y) in zip(xa, ya)]


### PR DESCRIPTION
While working on #300, I ran into a stackoverflow with printing out the full representation of `table`. I fixed this using `invoke` and added tests to catch future problems in the printing of both `table`s and `context`s.