### PR TITLE
re-enable keyword args to PNG, etc.

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -132,9 +132,9 @@ macro missing_cairo_error(backend)
 end
 
 #global PDF
-PNG(::Any, args...) = error(@missing_cairo_error "PNG")
-PS(::Any, args...) = error(@missing_cairo_error "PS")
-PDF(::Any, args...) = error(@missing_cairo_error "PDF")
+PNG(args...; kwargs...) = error(@missing_cairo_error "PNG")
+PS(args...; kwargs...) = error(@missing_cairo_error "PS")
+PDF(args...; kwargs...) = error(@missing_cairo_error "PDF")
 
 include("svg.jl")
 include("pgf_backend.jl")

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -182,14 +182,9 @@ Image{B}(width::MeasureOrNumber=default_graphic_width,
             dpi = (B==PNGBackend ? 96 : 72)) where {B<:ImageBackend} =
         Image{B}(IOBuffer(), width, height, emit_on_finish, dpi=dpi)
 
-PNG(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
-    Image{PNGBackend}(x, args...)
-
-PDF(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
-    Image{PDFBackend}(x, args...)
-
-PS(x::Union{CairoSurface,IO,AbstractString,MeasureOrNumber}, args...) =
-    Image{PSBackend}(x, args...)
+PNG(args...; kwargs...) = Image{PNGBackend}(args...; kwargs...)
+PDF(args...; kwargs...) = Image{PDFBackend}(args...; kwargs...)
+PS(args...; kwargs...) = Image{PSBackend}(args...; kwargs...)
 
 const CAIROSURFACE = Image{CairoBackend}
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,5 +1,6 @@
 using Test, Random
 using Colors
+import Cairo
 
 # showcompact
 @testset "printing" begin
@@ -136,4 +137,8 @@ end
         @test y_solution ≈ [5.275, 80.025]
         @test h_solution == [74.75, 4.7]
     end
+end
+
+@testset "Image keyword args" begin
+    @test typeof(PNG("foo.png", 4inch, 3inch, dpi=172)) <: Compose.Image
 end


### PR DESCRIPTION
`PNG(...; dpi=192)` no longer works after the refactoring for julia 0.7.  this fixes it.