### PR TITLE
avoid string copy

### DIFF
--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -527,7 +527,7 @@ end
 # FIX ME!
 function pango_to_pgf(text::AbstractString)
     pat = r"<(/?)\s*([^>]*)\s*>"
-    input = Array{UInt8}(escape_tex_chars(text))
+    input = codeunits(escape_tex_chars(text))
     output = IOBuffer()
     lastpos = 1
     for mat in eachmatch(pat, text)


### PR DESCRIPTION
this warning came up in the unit tests:

```
┌ Warning: Array{UInt8}(s::String) will copy data in the future. To avoid copying, use `unsafe_wrap` or `codeunits` instead.
│   caller = pango_to_pgf(::String) at pgf_backend.jl:530
└ @ Compose ~/.julia/dev/Compose/src/pgf_backend.jl:530
```