### PR TITLE
Fillopacity

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -10,6 +10,7 @@ makedocs(
         "Tutorial" => "tutorial.md",
         "Gallery" => Any[
             "Forms" => "gallery/forms.md",
+            "Properties"=> "gallery/properties.md",
             ],
         "Library" => "library.md"
     ]

--- a/docs/src/gallery/properties.md
+++ b/docs/src/gallery/properties.md
@@ -1,0 +1,21 @@
+```@meta
+Author = ["Mattriks"]
+```
+
+
+# [Properties](@id properties_gallery)
+
+## [`fill`](@ref), [`fillopacity`](@ref)
+ 
+```@example
+using Compose
+set_default_graphic_size(14cm,4cm)
+img = compose(context(),
+  (context(), circle(0.5, 0.5, 0.08), fillopacity(0.3), fill("orange")),
+  (context(), circle([0.1, 0.26], [0.5], [0.1]), fillopacity(0.3), fill("blue")),
+  (context(), circle([0.42, 0.58], [0.5], [0.1]), fillopacity(0.3), fill(["yellow","green"])),
+  (context(), circle([0.74, 0.90], [0.5], [0.1]), fillopacity([0.5,0.3]), fill(["yellow","red"]) )     
+)
+```
+
+

--- a/src/property.jl
+++ b/src/property.jl
@@ -69,7 +69,19 @@ end
 const Fill = Property{FillPrimitive}
 
 fill(c::Nothing) = Fill([FillPrimitive(RGBA{Float64}(0.0, 0.0, 0.0, 0.0))])
+
+"""
+    fill(c)
+
+Define a fill color, where `c` can be a `Colorant` or `String`.
+"""
 fill(c::Union{Colorant, AbstractString}) = Fill([FillPrimitive(parse_colorant(c))])
+
+"""
+    fill(cs::AbstractArray)
+
+Arguments can be passed in arrays in order to perform multiple drawing operations at once.
+"""
 fill(cs::AbstractArray) = Fill([FillPrimitive(c == nothing ?
         RGBA{Float64}(0.0, 0.0, 0.0, 0.0) : parse_colorant(c)) for c in cs])
 
@@ -196,7 +208,18 @@ end
 
 const FillOpacity = Property{FillOpacityPrimitive}
 
+"""
+    fillopacity(value)
+
+Define a fill opacity, where 0≤value≤1.
+"""
 fillopacity(value::Float64) = FillOpacity([FillOpacityPrimitive(value)])
+
+"""
+    fillopacity(values::AbstractArray)
+
+Arguments can be passed in arrays in order to perform multiple drawing operations at once.
+"""
 fillopacity(values::AbstractArray) =
         FillOpacity([FillOpacityPrimitive(value) for value in values])
 

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -636,7 +636,7 @@ function print_property(img::SVG, property::LineWidthPrimitive)
 end
 
 function print_property(img::SVG, property::FillOpacityPrimitive)
-    print(img.out, " opacity=\"")
+    print(img.out, " fill-opacity=\"")
     svg_print_float(img.out, property.value)
     print(img.out, '"')
 end
@@ -711,9 +711,9 @@ function print_vector_properties(img::SVG, idx::Int, supress_fill::Bool=false)
 
         # let the opacity primitives clobber the alpha value in fill and stroke
         if propertytype == Fill && has_fill_opacity
-           print_property(img, FillPrimitive(RGBA{Float64}(property.primitives[idx].color, 1.0)))
+           print_property(img, FillPrimitive(RGBA{Float64}(color(property.primitives[idx].color), 1.0)))
         elseif propertytype == Stroke && has_stroke_opacity
-           print_property(img, StrokePrimitive(RGBA{Float64}(property.primitives[idx].color, 1.0)))
+           print_property(img, StrokePrimitive(RGBA{Float64}(color(property.primitives[idx].color), 1.0)))
         else
             print_property(img, property.primitives[idx])
         end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -151,3 +151,11 @@ end
     withcompose = rand()
     @test withoutcompose == withcompose
 end
+
+@testset "Image fillopacity" begin
+    properties = [fill(["red","blue"]), fillopacity(0.3), stroke("black")]
+    img1 = PNG(); Compose.push_property_frame(img1, properties)
+    img2 = SVG(); Compose.push_property_frame(img2, properties)
+    @test getfield.(img1.vector_properties[Compose.Property{Compose.FillOpacityPrimitive}].primitives, :value) == [0.3, 0.3]
+    @test occursin("fill-opacity=\"0.3\"", String(img2.out.data))
+end    


### PR DESCRIPTION
This PR:
- Fixes #181 (so that `fillopacity` is not order-dependent)
- Enables scalar and vector `fillopacity` and forms to work together
- Begins a new `Properties` gallery for the Compose docs (will be added to other PRs)

Example:
```
set_default_graphic_size(14cm,4cm)
img = compose(context(),
  (context(), circle(0.5, 0.5, 0.08), fill("orange"), fillopacity(0.3)),
  (context(), circle([0.1, 0.26], [0.5], [0.1]), fillopacity(0.3), fill("blue")),
  (context(), circle([0.42, 0.58], [0.5], [0.1]), fill(["yellow","green"]), fillopacity(0.3)),
  (context(), circle([0.74, 0.90], [0.5], [0.1]),  fillopacity([0.5,0.3]), fill(["yellow","red"]))
)

draw(PNG(), img)
# draw(SVG(), img) # will also work
```
![iss_314](https://user-images.githubusercontent.com/18226881/46581171-8ec91400-ca7f-11e8-869d-6e0a76b6702e.png)



