### PR TITLE
Upgrade svg_fmt_color to svg rgba spec

### DIFF
--- a/src/property.jl
+++ b/src/property.jl
@@ -211,7 +211,7 @@ const FillOpacity = Property{FillOpacityPrimitive}
 """
     fillopacity(value)
 
-Define a fill opacity, where 0≤value≤1.
+Define a fill opacity, where 0≤value≤1. Note for svg alphas multiply: e.g. using `fill(RGBA(r,g,b,a₁))` and `fillopacity(a₂)` together will result in an opacity=a₁*a₂. 
 """
 fillopacity(value::Float64) = FillOpacity([FillOpacityPrimitive(value)])
 

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -85,6 +85,9 @@ end
 # Format a color for SVG.
 svg_fmt_color(c::Color) = string("#", hex(c))
 svg_fmt_color(c::Nothing) = "none"
+svg_fmt_color(c::CT) where CT<:TransparentColor =
+    string("rgba(", join(floor.(Int,[c.r,c.g,c.b].*255),","), ",", svg_fmt_float(c.alpha),")")
+
 
 # Replace newlines in a string with the appropriate SVG tspan tags.
 function svg_newlines(input::AbstractString, x::Float64)
@@ -591,12 +594,7 @@ function print_property(img::SVG, property::StrokePrimitive)
 end
 
 function print_property(img::SVG, property::FillPrimitive)
-    if property.color.alpha != 1.0
-        @printf(img.out, " fill=\"%s\" fill-opacity=\"%0.3f\"",
-                svg_fmt_color(color(property.color)), property.color.alpha)
-    else
-        @printf(img.out, " fill=\"%s\"", svg_fmt_color(color(property.color)))
-    end
+        @printf(img.out, " fill=\"%s\"", svg_fmt_color(property.color))
 end
 
 function print_property(img::SVG, property::StrokeDashPrimitive)
@@ -698,7 +696,6 @@ function print_vector_properties(img::SVG, idx::Int, supress_fill::Bool=false)
     end
 
     has_stroke_opacity = haskey(img.vector_properties, StrokeOpacity)
-    has_fill_opacity = haskey(img.vector_properties, FillOpacity)
 
     for (propertytype, property) in img.vector_properties
         if property === nothing ||
@@ -709,10 +706,8 @@ function print_vector_properties(img::SVG, idx::Int, supress_fill::Bool=false)
         idx > length(property.primitives) &&
                 error("Vector form and vector property differ in length. Can't distribute.")
 
-        # let the opacity primitives clobber the alpha value in fill and stroke
-        if propertytype == Fill && has_fill_opacity
-           print_property(img, FillPrimitive(RGBA{Float64}(color(property.primitives[idx].color), 1.0)))
-        elseif propertytype == Stroke && has_stroke_opacity
+        # let the opacity primitive clobber the alpha value in stroke
+        if propertytype == Stroke && has_stroke_opacity
            print_property(img, StrokePrimitive(RGBA{Float64}(color(property.primitives[idx].color), 1.0)))
         else
             print_property(img, property.primitives[idx])

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -156,6 +156,9 @@ end
     properties = [fill(["red","blue"]), fillopacity(0.3), stroke("black")]
     img1 = PNG(); Compose.push_property_frame(img1, properties)
     img2 = SVG(); Compose.push_property_frame(img2, properties)
+    Compose.print_vector_properties.([img2], [1,2])
+    a = String(img2.out.data)
     @test getfield.(img1.vector_properties[Compose.Property{Compose.FillOpacityPrimitive}].primitives, :value) == [0.3, 0.3]
-    @test occursin("fill-opacity=\"0.3\"", String(img2.out.data))
+    @test occursin("fill-opacity=\"0.3\"", a)
+    @test all(occursin.(["fill=\"rgba(255,0,0,1)\"","fill=\"rgba(0,0,255,1)\""], a))
 end    


### PR DESCRIPTION
Fixes #318
- [x] I've updated the documentation to reflect these changes
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests
- [x]  I've built the Compose docs and confirmed these changes don't cause new errors
- [x] I've run the Gadfly tests with this PR

### This PR 
- upgrades `svg_fmt_color()` to include a method for the svg `rgba` spec.
- This means opacity can be specified twice: in `fill(c)` and `fillopacity(a)`, producing the same result as in the svg backend (alphas multiply). 
