### PR TITLE
ngons, stars and xgons

### DIFF
--- a/docs/src/gallery/forms.md
+++ b/docs/src/gallery/forms.md
@@ -94,6 +94,22 @@ img = compose(context(),
 )
 ```
 
+## [`ngon`](@ref), [`star`](@ref), [`xgon`](@ref) 
+```@example
+using Compose
+set_default_graphic_size(14cm, 5cm)
+rainbow = ["orange","green","indigo",
+    "darkviolet","indigo","blue","green","yellow","orange","red"]
+properties = [fillopacity(0.5), fill(rainbow), stroke("black")]
+npoints = [7,5,3,2,3,4,5,6,7,8]
+X = range(0.06, stop=0.94, length=10)
+radii = 0.035*[-ones(3); ones(7)]
+p = compose(context(),
+    (context(), ngon(X, [0.16], radii, npoints),
+        star(X, [0.5], radii, npoints),
+        xgon(X, [0.84], radii, npoints), properties...))
+```
+
 ## [`polygon`](@ref)
 ```@example
 using Statistics, Compose

--- a/examples/polygon_forms.jl
+++ b/examples/polygon_forms.jl
@@ -1,0 +1,8 @@
+
+using Compose
+
+compose(context(),
+    ngon(0.15, 0.15, 0.08, 5),
+    star(0.35, 0.15, 0.08, 5, 0.3),
+    xgon(0.55, 0.15, 0.08, 5, 0.3)
+) |> SVG("polygon_forms.svg", 3inch, 3inch)

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -17,7 +17,8 @@ import Measures: resolve, w, h
 
 export compose, compose!, Context, UnitBox, AbsoluteBoundingBox, Rotation, Mirror,
        ParentDrawContext, context, ctxpromise, table, set_units!, minwidth, minheight,
-       text_extents, max_text_extents, polygon, line, rectangle, circle, arc, sector,
+       text_extents, max_text_extents, polygon, ngon, star, xgon,
+       line, rectangle, circle, arc, sector,
        ellipse, text, curve, bitmap, stroke, fill, strokedash, strokelinecap,
        strokelinejoin, linewidth, visible, fillopacity, strokeopacity, clip,
        font, fontsize, svgid, svgclass, svgattribute, jsinclude, jscall, Measure,

--- a/src/form.jl
+++ b/src/form.jl
@@ -700,6 +700,104 @@ form_string(::Arc) = "A"
 
 
 
+### Polygon primitive forms
+
+"""
+    ngon(x, y, r, n::Int)
+
+Define a `n`-sided polygon with its center at (`x`,`y`), and radius of `r`.  For an upside-down ngon, use `-r`.  
+"""
+function ngon(x, y, r, n::Int, tag=empty_tag)
+    θ = range(-π/2, stop=1.5π, length=n+1)
+    x1 = x_measure(x) .+ x_measure(r).*cos.(θ)
+    y1 = y_measure(y) .+ x_measure(r).*sin.(θ)
+    points = collect(Tuple{Measure, Measure}, zip(x1, y1))
+    return Form([PolygonPrimitive(points)], tag)
+end
+
+
+"""
+    ngon(xs::AbstractVector, ys::AbstractVector, rs::AbstractVector, ns::AbstractVector{Int})
+
+Arguments can be passed in arrays in order to perform multiple drawing operations at once.
+"""
+function ngon(xs::AbstractVector, ys::AbstractVector, rs::AbstractVector, ns::AbstractVector{Int}, tag=empty_tag)
+    VecType = Tuple{Measure, Measure}
+    PrimType = PolygonPrimitive{VecType}
+    polyprims = PrimType[]
+    for (x, y, r, n) in Compose.cyclezip(xs, ys, rs, ns)
+        p = ngon( x, y, r, n)
+        push!(polyprims, PrimType(p.primitives[1].points))
+    end
+    return Form{PrimType}(polyprims, tag)
+end
+
+
+"""
+    star(x, y, r, n::Int, ratio)
+
+Define a `n`-pointed star with its center at (`x`,`y`), outer radius of `r`, and inner radius equal to `r*ratio`. For an upside-down star, use `-r`.
+"""
+function star(x, y, r, n::Int, ratio::Float64=0.3, tag=empty_tag)
+    θ = range(-π/2, stop=1.5π, length=2*n+1)[1:end-1]
+    r1 = repeat([r, r*ratio], outer=n)
+    x1 = x_measure(x) .+ x_measure(r1).*cos.(θ)
+    y1 = y_measure(y) .+ x_measure(r1).*sin.(θ)
+    points = collect(Tuple{Measure, Measure}, zip(x1, y1))
+    return Form([PolygonPrimitive(points)], tag)
+end
+
+
+"""
+    star(xs::AbstractVector, ys::AbstractVector, rs::AbstractVector, ns::AbstractVector{Int}, ratios::AbstractVector{Float64})
+
+Arguments can be passed in arrays in order to perform multiple drawing operations at once.
+"""
+function star(xs::AbstractVector, ys::AbstractVector, rs::AbstractVector, ns::AbstractVector{Int}, ratios::AbstractVector{Float64}=[0.3], tag=empty_tag)
+    VecType = Tuple{Measure, Measure}
+    PrimType = PolygonPrimitive{VecType}
+    polyprims = PrimType[]
+    for (x, y, r, n, ratio) in Compose.cyclezip(xs, ys, rs, ns, ratios)
+        p = star( x, y, r, n, ratio)
+        push!(polyprims, PrimType(p.primitives[1].points))
+    end
+    return Form{PrimType}(polyprims, tag)
+end
+
+
+"""
+    xgon(x, y, r, n::Int, ratio)
+
+Define a cross with `n` arms with its center at (`x`,`y`), outer radius of `r`, and inner radius equal to `r*ratio`. For an upside-down xgon, use `-r`.
+"""
+function xgon(x, y, r, n::Int, ratio::Float64=0.1, tag=empty_tag)
+    θ₁ = range(-0.75π, stop=1.25π, length=n+1)[1:end-1]
+    w = 2*r*ratio*sin(π/n)
+    dₒ = abs(asin(0.5*w/r))
+    dᵢ = abs(asin(0.5*w/(r*ratio)))   
+    r₂ = repeat([r*ratio,r,r], outer=n)
+    θ₂ = vec([θ+x  for x in [-dᵢ, -dₒ, dₒ], θ in θ₁])
+    x1 = x_measure(x) .+ x_measure(r₂).*cos.(θ₂)
+    y1 = y_measure(y) .+ x_measure(r₂).*sin.(θ₂)
+    points = collect(Tuple{Measure, Measure}, zip(x1, y1))
+    return Form([PolygonPrimitive(points)], tag)
+end
+
+"""
+    xgon(xs::AbstractVector, ys::AbstractVector, rs::AbstractVector, ns::AbstractVector{Int}, ratios::AbstractVector{Float64})
+
+Arguments can be passed in arrays in order to perform multiple drawing operations at once.
+"""
+function xgon(xs::AbstractVector, ys::AbstractVector, rs::AbstractVector, ns::AbstractVector{Int}, ratios::AbstractVector{Float64}=[0.3], tag=empty_tag)
+    VecType = Tuple{Measure, Measure}
+    PrimType = PolygonPrimitive{VecType}
+    polyprims = PrimType[]
+    for (x, y, r, n, ratio) in Compose.cyclezip(xs, ys, rs, ns, ratios)
+        p = xgon(x, y, r, n, ratio)
+        push!(polyprims, PrimType(p.primitives[1].points))
+    end
+    return Form{PrimType}(polyprims, tag)
+end
 
 
 

--- a/test/data/polygon_forms.svg
+++ b/test/data/polygon_forms.svg
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:xlink="http://www.w3.org/1999/xlink"
+     version="1.2"
+     width="76.2mm" height="76.2mm" viewBox="0 0 76.2 76.2"
+     stroke="none"
+     fill="#000000"
+     stroke-width="0.3"
+     font-size="3.88"
+>
+<g transform="translate(41.91,11.43)">
+  <path d="M-1.81,-0.29 L -5 -3.48 -3.48 -5 -0.29 -1.81 1.77 -5.83 3.68 -4.86 1.63 -0.83 6.09 -0.12 5.76 2 1.29 1.29 2 5.76 -0.12 6.09 -0.83 1.63 -4.86 3.68 -5.83 1.77 z" class="primitive"/>
+</g>
+<g transform="translate(26.67,11.43)">
+  <path d="M0,-6.1 L 1.07 -1.48 5.8 -1.88 1.74 0.57 3.58 4.93 0 1.83 -3.58 4.93 -1.74 0.57 -5.8 -1.88 -1.07 -1.48 z" class="primitive"/>
+</g>
+<g transform="translate(11.43,10.41)">
+  <path d="M0,-5.08 L 5.8 -0.87 3.58 5.95 -3.58 5.95 -5.8 -0.87 -0 -5.08 z" class="primitive"/>
+</g>
+</svg>


### PR DESCRIPTION
### This PR:
- [x]  Adds functions `ngon()`, `star()` and `xgon()`, for drawing `n`-"pointed" polygons, stars and crosses.    
The method is e.g. `star(x, y, r, n, [,ratio])`
- [x] Documentation added.
- [x] Unit test added.

### Example
```julia
set_default_graphic_size(14cm, 5cm)
rainbow = ["orange","green","indigo",
    "darkviolet","indigo","blue","green","yellow","orange","red"]
properties = [fillopacity(0.5), fill(rainbow), stroke("black")]
npoints = [7,5,3,2,3,4,5,6,7,8]
X = range(0.06, stop=0.94, length=10)
radii = 0.035*[-ones(3); ones(7)]
p = compose(context(),
    (context(), ngon(X, [0.16], radii, npoints),
        star(X, [0.5], radii, npoints),
        xgon(X, [0.84], radii, npoints), properties...))
```
![nsx_gons](https://user-images.githubusercontent.com/18226881/47262382-25dba480-d533-11e8-83c1-094629cd26f1.png)


