### PR TITLE
Requires.jl uses relative import

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -1,4 +1,4 @@
-import Cairo: CairoContext, CairoSurface, CairoARGBSurface, CairoEPSSurface,
+import .Cairo: CairoContext, CairoSurface, CairoARGBSurface, CairoEPSSurface,
 CairoPDFSurface, CairoSVGSurface, CairoImageSurface
 
 abstract type ImageBackend end


### PR DESCRIPTION
Before:
```
julia> using Compose
julia> using Cairo
[ Info: Loading Cairo backend into Compose.jl
┌ Warning: Package Compose does not have Cairo in its dependencies:
│ - If you have Compose checked out for development and have
│   added Cairo as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with Compose
└ Loading Cairo into Compose from project dependency, future warnings for Compose are suppressed.
```

After:
```
julia> using Compose

julia> using Cairo
[ Info: Loading Cairo backend into Compose.jl

julia> using Fontconfig
[ Info: Loading Fontconfig backend into Compose.jl
```