### PR TITLE
Rotation

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -11,6 +11,7 @@ makedocs(
         "Gallery" => Any[
             "Forms" => "gallery/forms.md",
             "Properties"=> "gallery/properties.md",
+            "Transformations"=> "gallery/transforms.md",
             ],
         "Library" => "library.md"
     ]

--- a/docs/src/gallery/transforms.md
+++ b/docs/src/gallery/transforms.md
@@ -1,0 +1,31 @@
+```@meta
+Author = ["Mattriks"]
+```
+
+
+# [Transformations](@id transforms_gallery)
+
+## [`Rotation`](@ref)
+ 
+```@example
+using Compose
+set_default_graphic_size(15cm,5cm)
+
+# This example also illustrates nested contexts
+f_points = [(.1, .1), (.9, .1), (.9, .2), (.2, .2), (.2, .4),
+    (.6, .4), (.6, .5), (.2, .5), (.2, .9), (.1, .9), (.1, .1)]
+rect(c::String) = (context(), rectangle(), stroke(c))
+circ(c::String, s::Float64=0.4) =  (context(), circle([x],[y],[0.03,s]), stroke(c))
+fpoly(c::String) = (context(), polygon(f_points), fill(c))
+contextC(θ::Float64) = (context(0.5,0.5,1.5,1.5, units=UnitBox(0,0,1,1),
+        rotation=Rotation(θ,x,y)), fpoly("steelblue"), circ("orange"))
+imgf(θ::Float64) =  compose(context(), fill(nothing), rect("black"),
+        (context(0.15, 0.15, 0.7, 0.7, units=UnitBox(0,0,2,2)), rect("red"), 
+        contextC(θ)) # context C in context B in context A
+    ) 
+
+x, y, θ = 0.5, 0.25, π/3
+hstack(imgf(-θ), imgf(0.), imgf(θ))
+```
+
+

--- a/examples/golden_rect.jl
+++ b/examples/golden_rect.jl
@@ -5,10 +5,11 @@ using Compose
 using Base.MathConstants
 
 function golden_rect(n::Int)
+    poly_points = [(0, 0), (1, 0), (1, 1), (0, 1)]
     if n == 0 return context() end
-    c = compose(context(), rectangle(), fill(LCHab(90, 80, 70 - 15n)))
-    compose(c, context(units=UnitBox(0, -1/φ, 1h, 1/φ), rotation=Rotation(π/2, 0, 1)),  golden_rect(n - 1))
+    c = compose(context(), polygon(poly_points), fill(LCHab(90, 80, 70-20n)), stroke("black"))
+    compose(c, (context(0,0,1/φ,1/φ, rotation=Rotation(-π/2,1,0)),  golden_rect(n-1)))
 end
 
-draw(SVG("golden_rect.svg", φ * 3inch, 3inch),
-    compose(golden_rect(10), fill(nothing), stroke("white"), linewidth(0.2mm)))
+draw(SVG("golden_rect.svg", φ*3inch, 3inch),
+    compose(golden_rect(8), linewidth(0.2mm)))

--- a/src/container.jl
+++ b/src/container.jl
@@ -368,6 +368,10 @@ function drawpart(backend::Backend, container::Container,
     box = resolve(parent_box, units, parent_transform, ctx.box)
 
     transform = parent_transform
+    if ctx.units !== nothing
+        units = resolve(box, units, transform, ctx.units)
+    end
+
     if ctx.rot !== nothing
         rot = resolve(box, units, parent_transform, ctx.rot)
         transform = combine(convert(Transform, rot), transform)
@@ -393,9 +397,6 @@ function drawpart(backend::Backend, container::Container,
         return
     end
 
-    if ctx.units !== nothing
-        units = resolve(box, units, transform, ctx.units)
-    end
 
     has_properties = false
     if !isa(ctx.property_children, ListNull) || ctx.clip

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -189,8 +189,20 @@ end
 
 Rotation(theta::Number, offset::XYTupleOrVec) =
         Rotation(convert(Float64, theta), (x_measure(offset[1]), y_measure(offset[2])))
+
+"""
+    Rotation(θ, x, y)
+
+Rotate all forms in context around point `(x,y)` by angle `θ` in radians.  
+"""
 Rotation(theta::Number, offset_x, offset_y) =
         Rotation(convert(Float64, theta), (x_measure(offset_x), y_measure(offset_y)))
+
+"""
+    Rotation(θ)
+    
+`Rotation(θ)=Rotation(θ, 0.5w, 0.5h)`
+"""        
 Rotation(theta::Number) = Rotation{Vec2}(convert(Float64, theta), (0.5w, 0.5h))
 Rotation() = Rotation(0.0, (0.5w, 0.5h))
 
@@ -267,7 +279,7 @@ function resolve(box::AbsoluteBox, units::UnitBox, t::MatrixTransform, p::Vec2)
 end
 
 resolve(box::AbsoluteBox, units::UnitBox, t::Transform, a::BoundingBox) =
-        BoundingBox(resolve(box, units, t, a.x0),
+        BoundingBox(resolve(box, units, IdentityTransform(), a.x0),
             (resolve(box, units, t, a.a[1]), resolve(box, units, t, a.a[2])))
 
 resolve(box::AbsoluteBox, units::UnitBox, t::Transform, a::Rotation) =

--- a/test/data/golden_rect.svg
+++ b/test/data/golden_rect.svg
@@ -8,47 +8,42 @@
      stroke-width="0.3"
      font-size="3.88"
 >
-<g stroke-width="0.2" stroke="#FFFFFF" fill="#000000" fill-opacity="0.000" id="img-e6c61b5b-1">
+<defs>
+  <marker id="arrow" markerWidth="15" markerHeight="7" refX="5" refY="3.5" orient="auto" markerUnits="strokeWidth">
+    <path d="M0,0 L15,3.5 L0,7 z" stroke="context-stroke" fill="context-stroke"/>
+  </marker>
+</defs>
+<g stroke-width="0.2" stroke="#000000" fill="rgba(0,235,255,1)" id="img-063cc517-1">
   <g transform="translate(61.65,38.1)">
     <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
   </g>
-  <g fill="#CDD3FF" id="img-e6c61b5b-2">
-    <g transform="translate(61.65,38.1)">
-      <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
+  <g stroke="#000000" fill="rgba(180,216,255,1)" id="img-063cc517-2">
+    <g transform="translate(99.75,38.1)">
+      <path d="M-23.55,38.1 L -23.55 -38.1 23.55 -38.1 23.55 38.1 z" class="primitive"/>
     </g>
-    <g fill="#FFC3FF" id="img-e6c61b5b-3">
-      <g transform="translate(61.65,38.1)">
-        <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
+    <g stroke="#000000" fill="rgba(255,194,255,1)" id="img-063cc517-3">
+      <g transform="translate(99.75,14.55)">
+        <path d="M23.55,14.55 L -23.55 14.55 -23.55 -14.55 23.55 -14.55 z" class="primitive"/>
       </g>
-      <g fill="#FFB3FF" id="img-e6c61b5b-4">
-        <g transform="translate(61.65,38.1)">
-          <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
+      <g stroke="#000000" fill="rgba(255,173,255,1)" id="img-063cc517-4">
+        <g transform="translate(85.19,14.55)">
+          <path d="M8.99,-14.55 L 8.99 14.55 -8.99 14.55 -8.99 -14.55 z" class="primitive"/>
         </g>
-        <g fill="#FFA5FF" id="img-e6c61b5b-5">
-          <g transform="translate(61.65,38.1)">
-            <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
+        <g stroke="#000000" fill="rgba(255,157,255,1)" id="img-063cc517-5">
+          <g transform="translate(85.19,23.55)">
+            <path d="M-8.99,-5.56 L 8.99 -5.56 8.99 5.56 -8.99 5.56 z" class="primitive"/>
           </g>
-          <g fill="#FF9CF3" id="img-e6c61b5b-6">
-            <g transform="translate(61.65,38.1)">
-              <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
+          <g stroke="#000000" fill="rgba(255,154,203,1)" id="img-063cc517-6">
+            <g transform="translate(90.75,23.55)">
+              <path d="M-3.44,5.56 L -3.44 -5.56 3.44 -5.56 3.44 5.56 z" class="primitive"/>
             </g>
-            <g fill="#FF9BCC" id="img-e6c61b5b-7">
-              <g transform="translate(61.65,38.1)">
-                <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
+            <g stroke="#000000" fill="rgba(255,164,154,1)" id="img-063cc517-7">
+              <g transform="translate(90.75,20.11)">
+                <path d="M3.44,2.12 L -3.44 2.12 -3.44 -2.12 3.44 -2.12 z" class="primitive"/>
               </g>
-              <g fill="#FFA1A6" id="img-e6c61b5b-8">
-                <g transform="translate(61.65,38.1)">
-                  <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
-                </g>
-                <g fill="#FFAD84" id="img-e6c61b5b-9">
-                  <g transform="translate(61.65,38.1)">
-                    <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
-                  </g>
-                  <g fill="#FFBC65" id="img-e6c61b5b-10">
-                    <g transform="translate(61.65,38.1)">
-                      <path d="M-61.65,-38.1 L 61.65 -38.1 61.65 38.1 -61.65 38.1 z" class="primitive"/>
-                    </g>
-                  </g>
+              <g stroke="#000000" fill="rgba(255,183,110,1)" id="img-063cc517-8">
+                <g transform="translate(88.63,20.11)">
+                  <path d="M1.31,-2.12 L 1.31 2.12 -1.31 2.12 -1.31 -2.12 z" class="primitive"/>
                 </g>
               </g>
             </g>


### PR DESCRIPTION
### This PR:
- [x] Fixes #178
- [x] Makes the `golden_rect.jl` rotation test example work (properly closes #273)
- [x] Adds a new `transforms.md` page to the gallery.

### Example:
```julia
set_default_graphic_size(15cm,5cm)
f_points = [(.1, .1), (.9, .1), (.9, .2), (.2, .2), (.2, .4),
    (.6, .4), (.6, .5), (.2, .5), (.2, .9), (.1, .9), (.1, .1)]
rect(c::String) = (context(), rectangle(), stroke(c))
circ(c::String, x, y, s=0.4) =  (context(), circle([x],[y],[0.03,s]), stroke(c))
fpoly(c::String) = (context(), polygon(f_points), fill(c))

imgf(θ,x=0.5,y=0.5) = compose(context(), fill(nothing), rect("black"),
    (context(0.15, 0.15, 0.7, 0.7, rotation=Rotation(θ,x,y)), 
        fpoly("steelblue"), circ("orange",x,y,0.5)))

hstack(imgf(-π/3), imgf(0.), imgf(π/6,0.2,0.9))
```
![rotation](https://user-images.githubusercontent.com/18226881/48667024-2ca10b80-eb21-11e8-8a04-143f19b14d77.png)
