### PR TITLE
svg_alpha_test

### DIFF
--- a/docs/src/gallery/transforms.md
+++ b/docs/src/gallery/transforms.md
@@ -11,19 +11,19 @@ Author = ["Mattriks"]
 using Compose
 set_default_graphic_size(15cm,5cm)
 
-set_default_graphic_size(15cm,5cm)
 f_points = [(.1, .1), (.9, .1), (.9, .2), (.2, .2), (.2, .4), (.6, .4), (.6, .5),
     (.2, .5), (.2, .9), (.1, .9), (.1, .1)]
 f_points = (x->0.4.*x.+0.1).(f_points)
 fpoly(ϕ::Float64) = (context(rotation=Rotation(ϕ,0.3,0.46)), polygon(f_points))
 
-imgf(θ, ϕ=0.0, x=0.5,y=0.5) = compose(context(), fill("salmon"), fpoly(ϕ),
+imgfa(θ, ϕ=0.0, x=0.5,y=0.5) = compose(context(), 
+  fill("salmon"), fillopacity(1.0), fpoly(ϕ),
   (context(rotation=Rotation(θ,x,y)), line([(x-0.5,y),(x+0.5,y)]), circle(x,y, 0.02)),
   (context(mirror=Mirror(θ, x, y)), fpoly(ϕ))
 )
 
-F = hstack(imgf(-π/4), imgf(-π/2.2), imgf(π/4, 1π))
-img = compose(context(), rectangle(), fill(nothing), stroke("black"), F)
+Fmir = hstack(imgfa(-π/4), imgfa(-π/2.2), imgfa(π/4, 1π))
+img = compose(context(), rectangle(), fill(nothing), stroke("black"), Fmir)
 ```
 
 ## [`Rotation`](@ref)
@@ -37,16 +37,17 @@ f_points = [(.1, .1), (.9, .1), (.9, .2), (.2, .2), (.2, .4),
     (.6, .4), (.6, .5), (.2, .5), (.2, .9), (.1, .9), (.1, .1)]
 rect(c::String) = (context(), rectangle(), stroke(c))
 circ(c::String, s::Float64=0.4) =  (context(), circle([x],[y],[0.03,s]), stroke(c))
-fpoly(c::String) = (context(), polygon(f_points), fill(c))
+fpoly(c::String) = (context(), polygon(f_points), fill(c), fillopacity(1.0))
 contextC(θ::Float64) = (context(0.5,0.5,1.5,1.5, units=UnitBox(0,0,1,1),
         rotation=Rotation(θ,x,y)), fpoly("steelblue"), circ("orange"))
-imgf(θ::Float64) =  compose(context(), fill(nothing), rect("black"),
-        (context(0.15, 0.15, 0.7, 0.7, units=UnitBox(0,0,2,2)), rect("red"), 
+imgf(θ::Float64) =  compose(context(),
+        (context(0.15, 0.15, 0.7, 0.7, units=UnitBox(0,0,2,2)), rect("red"),
         contextC(θ)) # context C in context B in context A
-    ) 
+    )
 
 x, y, θ = 0.5, 0.25, π/3
-hstack(imgf(-θ), imgf(0.), imgf(θ))
+Frot =  hstack(imgf(-θ), imgf(0.), imgf(θ))
+img = compose(context(), rectangle(), fill(nothing), stroke("black"), Frot)
 ```
 
 

--- a/src/property.jl
+++ b/src/property.jl
@@ -211,7 +211,7 @@ const FillOpacity = Property{FillOpacityPrimitive}
 """
     fillopacity(value)
 
-Define a fill opacity, where 0≤value≤1.
+Define a fill opacity, where 0≤value≤1.  For svg, nested contexts  will inherit from parent contexts e.g. `(context(), fillopacity(a), (context(), fill(c::String), circle()))`.
 """
 fillopacity(value::Float64) = FillOpacity([FillOpacityPrimitive(value)])
 

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1108,6 +1108,7 @@ clippathurl(img::SVG, property::ClipPrimitive) = get!(() -> genid(img), img.clip
 
 function push_property_frame(img::SVG, properties::Vector{Property})
     isempty(properties) && return
+    svgalphatest(properties)
 
     frame = SVGPropertyFrame()
     applied_properties = Set{Type}()
@@ -1257,8 +1258,17 @@ end
 
 
 
+# Currently for svg, you can't use a transparent fill(color) and fillopacity() together,
+# so throw a warning if a user tries to do that. 
 
-
-
+function svgalphatest(properties::Vector{Property})
+    has_fill_opacity = any(isa.(properties, Property{FillOpacityPrimitive}))
+    !has_fill_opacity && return
+    is_fill = isa.(properties, Property{FillPrimitive})
+    !any(is_fill) && return
+    fillproperties = properties[is_fill][1]
+    has_alpha = any([alpha(x.color) for x in fillproperties.primitives].<1.0) 
+    has_alpha && @warn "For svg transparent colors, use either e.g. fill(RGBA(r,g,b,a)) or fillopacity(a), but not both."
+end
 
 


### PR DESCRIPTION

- [x] This PR closes #322 (for svg, throws a warning if a user attempts to use a transparent color, e.g. `RGBA(r,g,b,a)`, and `fillopacity(a)` together.
- [x] I fixed some examples in the Compose docs.
- [x] I built and checked the Compose docs.
- [x] I've run the regression tests for both Compose and Gadfly.

