### PR TITLE
Shear transformation

### DIFF
--- a/docs/src/gallery/transforms.md
+++ b/docs/src/gallery/transforms.md
@@ -50,4 +50,30 @@ Frot =  hstack(imgf(-θ), imgf(0.), imgf(θ))
 img = compose(context(), rectangle(), fill(nothing), stroke("black"), Frot)
 ```
 
+## [`Shear`](@ref)
+ 
+```@example
+using Compose
+set_default_graphic_size(15cm, 5cm)
+
+f_points = [(.1, .1), (.9, .1), (.9, .2), (.2, .2), (.2, .4), (.6, .4),
+    (.6, .5), (.2, .5), (.2, .9), (.1, .9), (.1, .1)]
+f_points = (x->0.5.*x.+0.3).(f_points)
+ctxl(θ, x, y) = (context(rotation=Rotation(θ, x, y)), circle(x,y, 0.01), 
+    line([(x-0.5,y),(x+0.5,y)]))
+fpoly(c::String) = (context(),  polygon(f_points), fill(c) )
+ctxf(θ, ϕ, s, x, y,c) = (context(rotation=Rotation(-θ, x, y), 
+        shear=Shear(s, ϕ, x, y)), fpoly(c))
+
+x, y, θ  = 0.5, 0.5, -π/6
+img1 = compose(context(), stroke("black"), ctxl(θ,x,y),  ctxf(0,0,0,x,y, "yellow"),
+    (context(), arc(x,y,0.3,π+θ,π-0.15), arrow()) )
+img2 = compose(context(), stroke("black"), ctxl(0,x,y),
+    ctxf(θ,0,1.8,x,y,"transparent"), ctxf(θ,0,0,x,y,"yellow"),
+    text(0.5, 0.1, "x' = x+y*shear", hcenter, vcenter) )
+img3 = compose(context(), stroke("black"), 
+    ctxl(θ, x, y), ctxf(0,θ,1.8,x,y,"yellow") )
+
+hstack(img1, img2, img3)
+```
 

--- a/examples/transformations.jl
+++ b/examples/transformations.jl
@@ -7,7 +7,9 @@ PDF("transformations.pdf", 7cm, 7cm)]
 
 img = compose(context(),
     (context(0,0,0.5,0.5), xgon(0.2,0.2,0.1,3,0.3),
-    (context(mirror=Mirror(-π/4, 0.4,0.4)), xgon(0.2,0.2,0.1,3,0.3)) )
+    (context(mirror=Mirror(-π/4, 0.4,0.4)), xgon(0.2,0.2,0.1,3,0.3)) ),
+    (context(0.5,0,0.5,0.5), xgon(0.5,0.5,0.2,3,0.3), fill("silver"),
+    (context(shear=Shear(0.8, 0, 0.5,0.5)), xgon(0.5,0.5,0.2,3,0.3), fill(nothing), stroke("black")) )
 )
 
 draw.(imgs, [img])

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -15,7 +15,8 @@ import Base: length, isempty, getindex, setindex!,
     min, max, abs, +, -, *, /, ==
 import Measures: resolve, w, h
 
-export compose, compose!, Context, UnitBox, AbsoluteBoundingBox, Rotation, Mirror,
+export compose, compose!, Context, UnitBox, AbsoluteBoundingBox,
+        Rotation, Mirror, Shear,
        ParentDrawContext, context, ctxpromise, table, set_units!, minwidth, minheight,
        text_extents, max_text_extents, polygon, ngon, star, xgon,
        line, rectangle, circle, arc, sector, ellipse, text, curve, bitmap, 

--- a/test/data/transformations.svg
+++ b/test/data/transformations.svg
@@ -13,6 +13,16 @@
     <path d="M0,0 L15,3.5 L0,7 z" stroke="context-stroke" fill="context-stroke"/>
   </marker>
 </defs>
+<g fill="#C0C0C0" id="img-d4c874e2-1">
+  <g transform="translate(52.5,17.5)">
+    <path d="M-2.03,0.54 L -6.07 -3.49 -3.49 -6.07 0.54 -2.03 6.06 -3.51 7 0.01 1.48 1.48 0.01 7 -3.51 6.06 z" class="primitive"/>
+  </g>
+  <g stroke="#000000" fill="#000000" fill-opacity="0.000" id="img-d4c874e2-2">
+    <g transform="translate(52.5,17.5)">
+      <path d="M-2.46,0.54 L -3.27 -3.49 1.36 -6.07 2.17 -2.03 8.86 -3.51 6.99 0.01 0.3 1.48 -5.59 7 -8.35 6.06 z" class="primitive"/>
+    </g>
+  </g>
+</g>
 <g transform="translate(7,7)">
   <path d="M-1.01,0.27 L -3.03 -1.75 -1.75 -3.03 0.27 -1.01 3.03 -1.75 3.5 0 0.74 0.74 0 3.5 -1.75 3.03 z" class="primitive"/>
 </g>

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -18,7 +18,7 @@ import Cairo
         # full printing
         show(io, context())
         str = String(take!(io))
-        @test str == "Context(Measures.BoundingBox{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}},Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}}((0.0w, 0.0h), (1.0w, 1.0h)), nothing, nothing, nothing, List([]), List([]), List([]), 0, false, false, false, false, nothing, nothing, 0.0, Symbol(\"\"))"
+        @test str == "Context(Measures.BoundingBox{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}},Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}}((0.0w, 0.0h), (1.0w, 1.0h)), nothing, nothing, nothing, nothing, List([]), List([]), List([]), 0, false, false, false, false, nothing, nothing, 0.0, Symbol(\"\"))"
     end
     @testset "table" begin
         t = Compose.Table(1, 1, UnitRange(1,1), UnitRange(3:3), aspect_ratio=1.6)


### PR DESCRIPTION
This PR:
- [x] Closes #115 (Rotation, Reflection and Shearing are the 3 main transformations)
- [x] Adds example test to examples/transformations.jl
- [x] Adds gallery example + documentation

```
set_default_graphic_size(15cm, 5cm)

f_points = [(.1, .1), (.9, .1), (.9, .2), (.2, .2), (.2, .4), (.6, .4),
    (.6, .5), (.2, .5), (.2, .9), (.1, .9), (.1, .1)]
f_points = (x->0.5.*x.+0.3).(f_points)

ctxl(θ, x, y) = (context(rotation=Rotation(θ, x, y)), circle(x,y, 0.01), 
    line([(x-0.5,y),(x+0.5,y)]))
fpoly(c::String) = (context(),  polygon(f_points), fill(c) )
ctxf(θ, ϕ, s, x, y,c) = (context(rotation=Rotation(-θ, x, y), 
        shear=Shear(s, ϕ, x, y)), fpoly(c))

x, y, θ  = 0.5, 0.5, -π/6

img1 = compose(context(), stroke("black"), ctxl(θ,x,y),  ctxf(0,0,0,x,y, "yellow"),
#    (context(), arc(x,y,0.3,π+θ,π-0.15), arrow())
)
img2 = compose(context(), stroke("black"), ctxl(0,x,y),
    ctxf(θ,0,1.8,x,y,"transparent"), ctxf(θ,0,0,x,y,"yellow"),
    text(0.5, 0.1, "x' = x+y*shear", hcenter, vcenter) )
img3 = compose(context(), stroke("black"), 
    ctxl(θ, x, y), ctxf(0,θ,1.8,x,y,"yellow") )

hstack(img1, img2, img3)
```
![fshear](https://user-images.githubusercontent.com/18226881/49479696-0ba61d80-f878-11e8-8f27-c734e1bd9ac4.png)
