### PR TITLE
SVG multiline text

### DIFF
--- a/docs/src/gallery/forms.md
+++ b/docs/src/gallery/forms.md
@@ -181,6 +181,23 @@ img = compose(context(units=UnitBox(0,0,2,2)),
 )
 ```
 
+```@example
+using Compose
+set_default_graphic_size(10cm,8cm)
+
+# This graphic illustrates text alignment
+txt = [x*"\n"*y for  x in ["hleft", "hcenter","hright"], 
+        y in ["vtop","vcenter","vbottom"] ]
+x = repeat(0.1w.*[1,5,9], outer=3)
+y = repeat(0.1h.*[1,5,9], inner=3)
+xp = repeat([hleft,hcenter,hright], outer=3)
+yp = repeat([vtop,vcenter,vbottom], inner=3)
+
+img = compose(context(),
+        (context(), circle(x, y, [0.01]), fill("red")),
+        text(x, y, txt, xp, yp), fontsize(14pt)
+)
+```
 
 
 


### PR DESCRIPTION
## This PR:
- [x] Enables multiline text for SVG
- [x] Fixes text alignment so it's consistent with PNG
- [x] Adds gallery example
- [x] closes GiovineItalia/Gadfly.jl#1225

## Example:
```julia
using Compose
set_default_graphic_size(10cm, 8cm)

txt = [x*"\n"*y for  x in ["hleft", "hcenter","hright"], 
        y in ["vtop","vcenter","vbottom"] ]
x = repeat(0.1w.*[1,5,9], outer=3)
y = repeat(0.1h.*[1,5,9], inner=3)
xp = repeat([hleft,hcenter,hright], outer=3)
yp = repeat([vtop,vcenter,vbottom], inner=3)

img = compose(context(),
        (context(), circle(x, y, [0.01]), fill("red")),
        text(x, y, txt, xp, yp), fontsize(14pt))
```
![svgtxt1](https://user-images.githubusercontent.com/18226881/50042176-a1ca1700-00b4-11e9-9d5e-08ef8c8eea10.png)
