### PR TITLE
added error messages for show methods involving Cairo

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -122,9 +122,9 @@ default_line_width = 0.3mm
 default_stroke_color = nothing
 default_fill_color = colorant"black"
 
-function missing_cairo_error(backend::String, invocation::String=backend*"(...)")
+function missing_cairo_error(backend::String, invocation::String=backend)
     """
-    The Cairo and Fontconfig packages are necessary for displaying as $backend.
+    The Cairo and Fontconfig packages are necessary for saving as $backend.
     Add them with the package manager if necessary, then run:
       import Cairo, Fontconfig
     before invoking $invocation.

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -138,6 +138,18 @@ PNG(args...; kwargs...) = error(@missing_cairo_error "PNG")
 PS(args...; kwargs...) = error(@missing_cairo_error "PS")
 PDF(args...; kwargs...) = error(@missing_cairo_error "PDF")
 
+function missing_cairo_error(mime::MIME)
+    """
+    The Cairo and Fontconfig packages are necessary for displaying with MIME"$mime".
+    Add them with the package manager if necessary, then run:
+      import Cairo, Fontconfig
+    before invoking show(::IO, ::MIME"$mime", ::Context).   
+    """
+end
+show(io::IO, m::MIME"image/png", ctx::Context) = error(missing_cairo_error(m))
+show(io::IO, m::MIME"application/ps", ctx::Context) = error(missing_cairo_error(m))
+show(io::IO, m::MIME"application/pdf", ctx::Context) = error(missing_cairo_error(m))
+
 include("svg.jl")
 include("pgf_backend.jl")
 

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -122,33 +122,24 @@ default_line_width = 0.3mm
 default_stroke_color = nothing
 default_fill_color = colorant"black"
 
-# Use cairo for the PNG, PS, PDF if it's installed.
-macro missing_cairo_error(backend)
-    msg1 = """
-    The Cairo and Fontconfig packages are necessary for the $(backend) backend.
+function missing_cairo_error(backend::String, invocation::String=backend*"(...)")
+    """
+    The Cairo and Fontconfig packages are necessary for displaying as $backend.
     Add them with the package manager if necessary, then run:
       import Cairo, Fontconfig
-    before invoking $(backend).
-    """
-    string(msg1)
-end
-
-#global PDF
-PNG(args...; kwargs...) = error(@missing_cairo_error "PNG")
-PS(args...; kwargs...) = error(@missing_cairo_error "PS")
-PDF(args...; kwargs...) = error(@missing_cairo_error "PDF")
-
-function missing_cairo_error(mime::MIME)
-    """
-    The Cairo and Fontconfig packages are necessary for displaying with MIME"$mime".
-    Add them with the package manager if necessary, then run:
-      import Cairo, Fontconfig
-    before invoking show(::IO, ::MIME"$mime", ::Context).   
+    before invoking $invocation.
     """
 end
-show(io::IO, m::MIME"image/png", ctx::Context) = error(missing_cairo_error(m))
-show(io::IO, m::MIME"application/ps", ctx::Context) = error(missing_cairo_error(m))
-show(io::IO, m::MIME"application/pdf", ctx::Context) = error(missing_cairo_error(m))
+function missing_cairo_error(m::MIME)
+    missing_cairo_error(string(m), "show(::IO, ::MIME\"$m\", ::Context)")
+end
+
+PNG(args...; kwargs...) = error(missing_cairo_error("PNG"))
+PS(args...; kwargs...) = error(missing_cairo_error("PS"))
+PDF(args...; kwargs...) = error(missing_cairo_error("PDF"))
+
+CairoMIME = Union{MIME"image/png", MIME"application/ps", MIME"application/pdf"}
+show(io::IO, m::CairoMIME, ctx::Context) = error(missing_cairo_error(m))
 
 include("svg.jl")
 include("pgf_backend.jl")

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -122,6 +122,7 @@ default_line_width = 0.3mm
 default_stroke_color = nothing
 default_fill_color = colorant"black"
 
+# If Cairo is not available, throw an error when trying to save with a Cairo backend
 function missing_cairo_error(backend::String, invocation::String=backend)
     """
     The Cairo and Fontconfig packages are necessary for saving as $backend.

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,5 +1,19 @@
 using Test, Random
 using Colors
+
+# must be before importing cairo
+@testset "missing cairo errors" begin
+    ctx = compose(context(), circle(), fill("gold"))
+    @test_throws ErrorException ctx |> PNG("test.png")
+    @test_throws ErrorException ctx |> PDF("test.pdf")
+    @test_throws ErrorException ctx |> PS("test.ps")
+
+    io = IOBuffer()
+    @test_throws ErrorException show(io, MIME("image/png"), ctx)
+    @test_throws ErrorException show(io, MIME("application/pdf"), ctx)
+    @test_throws ErrorException show(io, MIME("application/ps"), ctx)
+end
+
 import Cairo
 
 # showcompact


### PR DESCRIPTION
I was initially dismayed to find that there is no `show(io, ::MIME"image/png", ::Context)`. It took me a while to figure out that I needed to import Cairo. This PR adds helpful error messages about that.