### PR TITLE
Fix UndefVarError: pango_cairo_ctx not defined by Julia 1.x.

### DIFF
--- a/src/pango.jl
+++ b/src/pango.jl
@@ -56,6 +56,7 @@ mutable struct PangoLayout
 end
 
 function PangoLayout()
+    global pango_cairo_ctx
     layout = ccall((:pango_layout_new, libpango),
                    Ptr{Cvoid}, (Ptr{Cvoid},), pango_cairo_ctx)
     # TODO: finalizer?


### PR DESCRIPTION
Dear authors, 

Using Gadfly, and Fontconfig I have found that error in Julia 1.x:

`
 Warning: [TEMPORARY WORKAROUND, pangolayout] for plotting with Gadfly.jl, see https://github.com/GiovineItalia/Gadfly.jl/issues/1206
└ @ Compose ~/.julia/packages/Compose/wlPCt/src/pango.jl:67
┌ Warning: Error requiring Fontconfig from Compose:
│ LoadError: UndefVarError: pango_cairo_ctx not defined
│ Stacktrace:
│  [1] Compose.PangoLayout() at /mnt/home/daniel/.julia/packages/Compose/wlPCt/src/pango.jl:59
│  [2] top-level scope at none:0
│  [3] include at ./boot.jl:326 [inlined]
│  [4] include_relative(::Module, ::String) at ./loading.jl:1038
│  [5] include at ./sysimg.jl:29 [inlined]
│  [6] include(::String) at /mnt/home/daniel/.julia/packages/Compose/wlPCt/src/Compose.jl:1
│  [7] top-level scope at /mnt/home/daniel/.julia/packages/Compose/wlPCt/src/Compose.jl:172
│  [8] eval at ./boot.jl:328 [inlined]
│  [9] eval at /mnt/home/daniel/.julia/packages/Compose/wlPCt/src/Compose.jl:1 [inlined]
│  [10] (::getfield(Compose, Symbol("##118#124")))() at /mnt/home/daniel/.julia/packages/Requires/9Jse8/src/require.jl:67
│  [11] err(::getfield(Compose, Symbol("##118#124")), ::Module, ::String) at /mnt/home/daniel/.julia/packages/Requires/9Jse8/src/require.jl:38
│  [12] #117 at /mnt/home/daniel/.julia/packages/Requires/9Jse8/src/require.jl:66 [inlined]
│  [13] withpath(::getfield(Compose, Symbol("##117#123")), ::String) at /mnt/home/daniel/.julia/packages/Requires/9Jse8/src/require.jl:28
│  [14] (::getfield(Compose, Symbol("##116#122")))() at /mnt/home/daniel/.julia/packages/Requires/9Jse8/src/require.jl:65
│  [15] #invokelatest#1 at ./essentials.jl:742 [inlined]
│  [16] invokelatest at ./essentials.jl:741 [inlined]
│  [17] #3 at /mnt/home/daniel/.julia/packages/Requires/9Jse8/src/require.jl:19 [inlined]
│  [18] iterate at ./generator.jl:47 [inlined]
│  [19] _collect(::Array{Function,1}, ::Base.Generator{Array{Function,1},getfield(Requires, Symbol("##3#4"))}, ::Base.EltypeUnknown, ::Base.HasShape{1}) at ./array.jl:619
│  [20] map at ./array.jl:548 [inlined]
│  [21] loadpkg(::Base.PkgId) at /mnt/home/daniel/.julia/packages/Requires/9Jse8/src/require.jl:19
│  [22] #invokelatest#1 at ./essentials.jl:742 [inlined]
│  [23] invokelatest at ./essentials.jl:741 [inlined]
│  [24] require(::Base.PkgId) at ./loading.jl:861
│  [25] require(::Module, ::Symbol) at ./loading.jl:853
│  [26] eval(::Module, ::Any) at ./boot.jl:328
│  [27] eval_user_input(::Any, ::REPL.REPLBackend) at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPL.jl:85
│  [28] macro expansion at /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.1/REPL/src/REPL.jl:117 [inlined]
│  [29] (::getfield(REPL, Symbol("##26#27")){REPL.REPLBackend})() at ./task.jl:259
│ in expression starting at /mnt/home/daniel/.julia/packages/Compose/wlPCt/src/pango.jl:68
└ @ Requires ~/.julia/packages/Requires/9Jse8/src/require.jl:40
`

It seems that the variable pango_cairo_ctx is used, but it is not done
previously "global pango_cairo_ctx" in the function, as it is required for 
new versions of Julia. I have changed PangoLayout including that line.
