### PR TITLE
Use Refs rather than globals for atsign-requires dependencies

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -150,19 +150,20 @@ include("pgf_backend.jl")
 
 include("fontfallback.jl")
 
+const pango_cairo_ctx = Ref(C_NULL)
+const pango_cairo_fm = Ref(C_NULL)
+const pangolayout = Ref{Any}(nothing)
+
 function link_fontconfig()
-    global pango_cairo_ctx
-    global pango_cairo_fm
-    global pangolayout
     @info "Loading Fontconfig backend into Compose.jl"
-    pango_cairo_ctx = C_NULL
+    pango_cairo_ctx[] = C_NULL
 
     ccall((:g_type_init, libgobject), Cvoid, ())
-    pango_cairo_fm  = ccall((:pango_cairo_font_map_new, libpangocairo),
-                             Ptr{Cvoid}, ())
-    pango_cairo_ctx = ccall((:pango_font_map_create_context, libpango),
-                             Ptr{Cvoid}, (Ptr{Cvoid},), pango_cairo_fm)
-    pangolayout = PangoLayout()
+    pango_cairo_fm[]  = ccall((:pango_cairo_font_map_new, libpangocairo),
+                               Ptr{Cvoid}, ())
+    pango_cairo_ctx[] = ccall((:pango_font_map_create_context, libpango),
+                               Ptr{Cvoid}, (Ptr{Cvoid},), pango_cairo_fm[])
+    pangolayout[] = PangoLayout()
 end
 
 function link_cairo()

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -57,15 +57,11 @@ end
 
 function PangoLayout()
     layout = ccall((:pango_layout_new, libpango),
-                   Ptr{Cvoid}, (Ptr{Cvoid},), pango_cairo_ctx)
+                   Ptr{Cvoid}, (Ptr{Cvoid},), pango_cairo_ctx[])
     # TODO: finalizer?
 
     PangoLayout(layout)
 end
-
-# TODO temporary fix for plotting in Julia 0.7 (5 Nov 2018)
-@warn "[TEMPORARY WORKAROUND, pangolayout] for plotting with Gadfly.jl, see https://github.com/GiovineItalia/Gadfly.jl/issues/1206"
-const pangolayout = PangoLayout()
 
 # Set the layout's font.
 function pango_set_font(pangolayout::PangoLayout, family::AbstractString, pts::Number)
@@ -110,11 +106,11 @@ end
 #   A (width, height) tuple in absolute units.
 #
 function max_text_extents(font_family::AbstractString, pts::Float64, texts::AbstractString...)
-    pango_set_font(pangolayout::PangoLayout, font_family, pts)
+    pango_set_font(pangolayout[]::PangoLayout, font_family, pts)
     max_width  = 0mm
     max_height = 0mm
     for text in texts
-        (width, height) = pango_text_extents(pangolayout::PangoLayout, text)
+        (width, height) = pango_text_extents(pangolayout[]::PangoLayout, text)
         max_width  = max_width.value  < width.value  ? width  : max_width
         max_height = max_height.value < height.value ? height : max_height
     end
@@ -130,8 +126,8 @@ end
 
 # Return an array with the extents of each element
 function text_extents(font_family::AbstractString, pts::Float64, texts::AbstractString...)
-    pango_set_font(pangolayout::PangoLayout, font_family, pts)
-    return [pango_text_extents(pangolayout::PangoLayout, text) for text in texts]
+    pango_set_font(pangolayout[]::PangoLayout, font_family, pts)
+    return [pango_text_extents(pangolayout[]::PangoLayout, text) for text in texts]
 end
 
 text_extents(font_family::AbstractString, size::Measure, texts::AbstractString...) =


### PR DESCRIPTION
This appears to fix problems involving Compose, Cairo, and Fontconfig. The idea is to avoid using variables that get defined only via `global` statements that run only in `@require` blocks, and switch to a strategy to uses variables that are defined at precompilation time. Here I do that by defining the variables as `Ref`s, so I can update their contents when they get initialized.

Fixes https://github.com/GiovineItalia/Gadfly.jl/issues/1206
Replaces https://github.com/GiovineItalia/Compose.jl/pull/341

This is not based on deep knowledge of what packages are or are not needed for my plotting task. I was simply following https://github.com/JuliaGraphs/GraphPlot.jl and then responded to messages about needing to `import Cairo, Fontconfig`.