### PR TITLE
Change @info to @debug for @require events

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -155,7 +155,7 @@ const pango_cairo_fm = Ref(C_NULL)
 const pangolayout = Ref{Any}(nothing)
 
 function link_fontconfig()
-    @info "Loading Fontconfig backend into Compose.jl"
+    @debug "Loading Fontconfig backend into Compose.jl"
     pango_cairo_ctx[] = C_NULL
 
     ccall((:g_type_init, libgobject), Cvoid, ())
@@ -167,7 +167,7 @@ function link_fontconfig()
 end
 
 function link_cairo()
-    @info "Loading Cairo backend into Compose.jl"
+    @debug "Loading Cairo backend into Compose.jl"
     include(joinpath(@__DIR__,"cairo_backends.jl"))
     include(joinpath(@__DIR__,"immerse_backend.jl"))
 end


### PR DESCRIPTION
We use a number of packages that depend on Compose.jl in our package, and it is really confusing for users of our package to see these messages. They have no idea what Compose.jl or Cairo.jl is, or why they are seeing those messages. I feel in general that packages that are relatively low in the stack, like this one here, should be "quiet": most users really don't benefit from messages like these, they are just confusing.

I changed these to `@debug`, so that someone who is interested in them can enable output for that and still see them.