### PR TITLE
fix Fontconfig on julia 0.7

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -150,8 +150,8 @@ include("pgf_backend.jl")
 
 include("fontfallback.jl")
 
-const pango_cairo_ctx = Ref(C_NULL)
-const pango_cairo_fm = Ref(C_NULL)
+const pango_cairo_ctx = Ref{Ptr}(C_NULL)
+const pango_cairo_fm = Ref{Ptr}(C_NULL)
 const pangolayout = Ref{Any}(nothing)
 
 function link_fontconfig()

--- a/src/pango.jl
+++ b/src/pango.jl
@@ -333,7 +333,7 @@ function pango_to_svg(text::AbstractString)
 
     # TODO: do c_stripped_text and c_attr_list need to be freed?
 
-    text = unsafe_wrap(Array, c_stripped_text[])
+    text = unsafe_string(c_stripped_text[])
 
     last_idx = 1
     open_tag = false

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -130,6 +130,9 @@ twolines = text_extents(font_family, 8pt, "Peg\nPeg")[1]
 @test Compose.parse_colorant("red",colorant"blue") == [RGB(1.0,0.0,0.0), RGB(0.0,0.0,1.0)]
 
 # PR 263
+@test ~ @isdefined Fontconfig
+@test Compose.pango_to_svg("hello world") == "hello world"
+import Fontconfig
 @test Compose.pango_to_svg("hello world") == "hello world"
 
 @testset "pango" begin


### PR DESCRIPTION
https://github.com/GiovineItalia/Compose.jl/pull/342 nicely fixed the pango dependency hack for julia 1.0, but [broke it completely](https://github.com/GiovineItalia/Compose.jl/pull/342#commitcomment-32429115) on 0.7.  this fixes it.

@timholy this is pretty straightforward, but any comments?