### PR TITLE
docs for PNG, PS, PDF, SVG, PGF

### DIFF
--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -186,10 +186,10 @@ Image{B}(width::MeasureOrNumber=default_graphic_width,
 
 
 docfunc(f) = """
-    $f([out::Union{AbstractString, IOBuffer}, width=√200cm, height=10cm; dpi=72])
+    $f([out::Union{AbstractString, IOBuffer}], width=√200cm, height=10cm; dpi=$(f==:PNG ? 96 : 72))
 
 Create a [`Compose.$(f)backend`](@ref) with an associated file and specified width, height (as positional arguments)
-and dpi (as a keyword argument). For PNG, the default dpi is 96, otherwise 72. The first argument is optional and can be an [`IOBuffer`](@ref). 
+and dpi (as a keyword argument). The first argument is optional and can be an [`IOBuffer`](@ref). 
 Normally passed to [`draw`](@ref). 
 
 # Examples

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -183,9 +183,9 @@ Image{B}(width::MeasureOrNumber=default_graphic_width,
             dpi = (B==PNGBackend ? 96 : 72)) where {B<:ImageBackend} =
         Image{B}(IOBuffer(), width, height, emit_on_finish, dpi=dpi)
 
-PNG(args...; kwargs...) = Image{PNGBackend}(args...; kwargs...)
-PDF(args...; kwargs...) = Image{PDFBackend}(args...; kwargs...)
-PS(args...; kwargs...) = Image{PSBackend}(args...; kwargs...)
+#PNG(args...; kwargs...) = Image{PNGBackend}(args...; kwargs...)
+#PDF(args...; kwargs...) = Image{PDFBackend}(args...; kwargs...)
+#PS(args...; kwargs...) = Image{PSBackend}(args...; kwargs...)
 
 
 
@@ -199,15 +199,20 @@ and dpi (as a keyword argument). Normally passed to [`draw`](@ref).
 ```jldoctest
     using Gadfly, Cairo
     p = plot(x = 1:10, y=rand(10), Geom.line)
-    draw($(f)("myplot.$(lowercase(f))",10cm, 5cm, dpi=250),p)
+    draw($(f)("myplot.$(lowercase(String(f)))",10cm, 5cm, dpi=250),p)
 ```
 """
 
 
-for backend in [:PNG, :PDF, :PS]
-    str = docfunc(String(backend))
-    @eval @doc $str $backend
+for func in [:PNG, :PDF, :PS]
+    backend = Symbol(func, "Backend")
+    docstr = docfunc(func)
+    @eval $func(args...; kwargs...) = Image{$backend}(args...; kwargs...)
+    @eval @doc $docstr $func
+
 end
+
+
 
 const CAIROSURFACE = Image{CairoBackend}
 

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -193,7 +193,7 @@ docfunc(f) = """
     $f(filename::AbstractString, width::MeasureOrNumber, height::MeasureOrNumber; dpi)
 
 Create a [`Compose.$(f)backend`](@ref) with an associated file and specified width, height (as positional arguments)
-and dpi (as a keyword argument). Normally passed to [`draw`](@ref).
+and dpi (as a keyword argument). For PNG, the default dpi is 96, otherwise 72. Normally passed to [`draw`](@ref). 
 
 # Examples
 ```jldoctest

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -187,6 +187,28 @@ PNG(args...; kwargs...) = Image{PNGBackend}(args...; kwargs...)
 PDF(args...; kwargs...) = Image{PDFBackend}(args...; kwargs...)
 PS(args...; kwargs...) = Image{PSBackend}(args...; kwargs...)
 
+
+
+docfunc(f) = """
+    $f(filename::AbstractString, width::MeasureOrNumber, height::MeasureOrNumber; dpi)
+
+Create a [`Compose.$(f)backend`](@ref) with an associated file and specified width, height (as positional arguments)
+and dpi (as a keyword argument). Normally passed to [`draw`](@ref).
+
+# Examples
+```jldoctest
+    using Gadfly, Cairo
+    p = plot(x = 1:10, y=rand(10), Geom.line)
+    draw($(f)("myplot.$(lowercase(f))",10cm, 5cm, dpi=250),p)
+```
+"""
+
+
+for backend in [:PNG, :PDF, :PS]
+    str = docfunc(String(backend))
+    @eval @doc $str $backend
+end
+
 const CAIROSURFACE = Image{CairoBackend}
 
 function (img::Image)(x)

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -183,17 +183,14 @@ Image{B}(width::MeasureOrNumber=default_graphic_width,
             dpi = (B==PNGBackend ? 96 : 72)) where {B<:ImageBackend} =
         Image{B}(IOBuffer(), width, height, emit_on_finish, dpi=dpi)
 
-#PNG(args...; kwargs...) = Image{PNGBackend}(args...; kwargs...)
-#PDF(args...; kwargs...) = Image{PDFBackend}(args...; kwargs...)
-#PS(args...; kwargs...) = Image{PSBackend}(args...; kwargs...)
-
 
 
 docfunc(f) = """
-    $f(filename::AbstractString, width::MeasureOrNumber, height::MeasureOrNumber; dpi)
+    $f([out::Union{AbstractString, IOBuffer}, width=√200cm, height=10cm; dpi=72])
 
 Create a [`Compose.$(f)backend`](@ref) with an associated file and specified width, height (as positional arguments)
-and dpi (as a keyword argument). For PNG, the default dpi is 96, otherwise 72. Normally passed to [`draw`](@ref). 
+and dpi (as a keyword argument). For PNG, the default dpi is 96, otherwise 72. The first argument is optional and can be an [`IOBuffer`](@ref). 
+Normally passed to [`draw`](@ref). 
 
 # Examples
 ```jldoctest

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -126,7 +126,7 @@ Create a [`Compose.PGF`](@ref) with an associated file and specified width, heig
 (as positional arguments) and texfonts (as a keyword argument)
 Normally passed to [`draw`](@ref). First argument can be an [`IOBuffer`](@ref). If `only_tikz=true` 
 then the output is a "tikzpicture" otherwise the output is a complete latex document with headers/footer. 
-If `texfonts=false`, include "\\usepackage{fontspec}" in the headers, otherwise skip that include.
+If `texfonts=false`, include "\\usepackage{fontspec}" in the headers, otherwise do not.
 
 # Examples
 ```jldoctest

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -120,18 +120,13 @@ end
 
 # Write to a file.
 """
-    PGF(filename::AbstractString, width::MeasureOrNumber, height::MeasureOrNumber, only_tikz::Bool; texfonts::Bool)
+    PGF(filename::AbstractString, width=√200cm, height=10cm, only_tikz=false; texfonts=false)
 
 Create a [`Compose.PGF`](@ref) with an associated file and specified width, height and only_tikz 
 (as positional arguments) and texfonts (as a keyword argument)
-Normally passed to [`draw`](@ref). First argument can be an [`IOBuffer`](@ref)
-
-# Arguments
-+ `filename`: A filename or an IOBuffer
-+ `width=√200cm`: PGF width (~14cm)
-+ `height=10cm`: PGF height
-+ `only_tikz=false`: Controls whether the latex output generates a complete latex document with headers/footer or only "tikzpicture" header/footers 
-+ `texfonts=false`: If false include "\\usepackage{fontspec}" in the headers.
+Normally passed to [`draw`](@ref). First argument can be an [`IOBuffer`](@ref). If `only_tikz=true` 
+then the output is a "tikzpicture" otherwise the output is a commplete latex document with headers/footer. 
+If `texfonts=false`, include "\\usepackage{fontspec}" in the headers, otherwise skip that include.
 
 # Examples
 ```jldoctest

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -130,7 +130,7 @@ If `texfonts=false`, include "\\usepackage{fontspec}" in the headers, otherwise 
 
 # Examples
 ```jldoctest
-    using Gadfly, Cairo
+    using Gadfly
     p = plot(x = 1:10, y=rand(10), Geom.line)
     draw(PGF("myplot.tex",10cm, 5cm),p)
 ```

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -119,6 +119,27 @@ function PGF(out::IO,
 end
 
 # Write to a file.
+"""
+    PGF(filename::AbstractString, width::MeasureOrNumber, height::MeasureOrNumber, only_tikz::Bool; texfonts::Bool)
+
+Create a [`Compose.PGF`](@ref) with an associated file and specified width, height and only_tikz 
+(as positional arguments) and texfonts (as a keyword argument)
+Normally passed to [`draw`](@ref). First argument can be an [`IOBuffer`](@ref)
+
+# Arguments
++ `filename`: A filename or an IOBuffer
++ `width=√200cm`: PGF width (~14cm)
++ `height=10cm`: PGF height
++ `only_tikz=false`: Controls whether the latex output generates a complete latex document with headers/footer or only "tikzpicture" header/footers 
++ `texfonts=false`: If false include "\\usepackage{fontspec}" in the headers.
+
+# Examples
+```jldoctest
+    using Gadfly, Cairo
+    p = plot(x = 1:10, y=rand(10), Geom.line)
+    draw(PGF("myplot.tex",10cm, 5cm),p)
+```
+"""
 PGF(filename::AbstractString, width=default_graphic_width, height=default_graphic_height,
             only_tikz=false; texfonts=false) =
         PGF(open(filename, "w"), width, height, true, only_tikz;

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -125,7 +125,7 @@ end
 Create a [`Compose.PGF`](@ref) with an associated file and specified width, height and only_tikz 
 (as positional arguments) and texfonts (as a keyword argument)
 Normally passed to [`draw`](@ref). First argument can be an [`IOBuffer`](@ref). If `only_tikz=true` 
-then the output is a "tikzpicture" otherwise the output is a commplete latex document with headers/footer. 
+then the output is a "tikzpicture" otherwise the output is a complete latex document with headers/footer. 
 If `texfonts=false`, include "\\usepackage{fontspec}" in the headers, otherwise skip that include.
 
 # Examples

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -268,16 +268,11 @@ end
 
 # Write to a file.
 """
-    SVG(filename::AbstractString, width::MeasureOrNumber, height::MeasureOrNumber, jsmode)
+    SVG([output::Union{IO,AbstractString}, width=√200cm, height=10cm, jsmode=:none])
 
-Create a [`Compose.SVG`](@ref) with an associated file and specified width, height and jsmode (as positional arguments). 
-Normally passed to [`draw`](@ref). First argument can be an [`IOBuffer`](@ref)
-
-# Arguments
-+ `filename`: A filename or an IOBuffer
-+ `width=√200cm`: Image width. 
-+ `height=10cm`: Image height. 
-+ `jsmode=:none`:  Can be one of :none, :exclude, :embed, :linkabs, :linkrel
+Create a [`Compose.SVG`](@ref) with an associated output and specified width, height and jsmode (as positional arguments). 
+Normally passed to [`draw`](@ref). First argument is optional and can be an [`IOBuffer`](@ref) or a filename 
+[`AbstractString`](@ref).  `jsmode` can be one of `[:none, :exclude, :embed, :linkabs, :linkrel]`.
 
 # Examples
 ```jldoctest

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -266,9 +266,9 @@ function SVG(out::IO,
     return img
 end
 
-# Write to a file.
+# Write to a file or IOBugger.
 """
-    SVG([output::Union{IO,AbstractString}, width=√200cm, height=10cm, jsmode=:none])
+    SVG([output::Union{IO,AbstractString}], width=√200cm, height=10cm, jsmode=:none)
 
 Create a [`Compose.SVG`](@ref) with an associated output and specified width, height and jsmode (as positional arguments). 
 Normally passed to [`draw`](@ref). First argument is optional and can be an [`IOBuffer`](@ref) or a filename 
@@ -276,7 +276,7 @@ Normally passed to [`draw`](@ref). First argument is optional and can be an [`IO
 
 # Examples
 ```jldoctest
-    using Gadfly, Cairo
+    using Gadfly
     p = plot(x = 1:10, y=rand(10), Geom.line)
     draw(SVG("myplot.svg",10cm, 5cm),p)
 ```

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -266,7 +266,7 @@ function SVG(out::IO,
     return img
 end
 
-# Write to a file or IOBugger.
+# Write to a file or IOBuffer.
 """
     SVG([output::Union{IO,AbstractString}], width=√200cm, height=10cm, jsmode=:none)
 

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -267,6 +267,25 @@ function SVG(out::IO,
 end
 
 # Write to a file.
+"""
+    SVG(filename::AbstractString, width::MeasureOrNumber, height::MeasureOrNumber, jsmode)
+
+Create a [`Compose.SVG`](@ref) with an associated file and specified width, height and jsmode (as positional arguments). 
+Normally passed to [`draw`](@ref). First argument can be an [`IOBuffer`](@ref)
+
+# Arguments
++ `filename`: A filename or an IOBuffer
++ `width=√200cm`: Image width. 
++ `height=10cm`: Image height. 
++ `jsmode=:none`:  Can be one of :none, :exclude, :embed, :linkabs, :linkrel
+
+# Examples
+```jldoctest
+    using Gadfly, Cairo
+    p = plot(x = 1:10, y=rand(10), Geom.line)
+    draw(SVG("myplot.svg",10cm, 5cm),p)
+```
+"""
 SVG(filename::AbstractString, width=default_graphic_width, height=default_graphic_height,
         jsmode::Symbol=:none) =
         SVG(open(filename, "w"), width, height, true, jsmode; ownedfile=true, filename=filename)


### PR DESCRIPTION
+ Took suggestion from previous PR to put methods declarations in the loop
+ Added custom doc string for SVG and PGF, since they have different options.
+ note: PGF example uses `.tex` extension. Is that correct?