### PR TITLE
get docs to build again

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,9 +1,14 @@
 using Documenter, Compose
+import Cairo
+
+struct SVGJSWritable{T}
+    x :: T
+end
+Base.show(io::IO, m::MIME"text/html", x::SVGJSWritable) = show(io, m, x.x)
 
 makedocs(
     modules = [Compose],
-    clean = true,
-    format = :html,
+    clean = false,
     sitename = "Compose.jl",
     pages = Any[
         "Home" => "index.md",
@@ -19,5 +24,4 @@ makedocs(
 
 deploydocs(
     repo   = "github.com/GiovineItalia/Compose.jl.git",
-    target = "build"
 )

--- a/docs/src/gallery/forms.md
+++ b/docs/src/gallery/forms.md
@@ -25,6 +25,7 @@ hstack(img1, img2)
 
 ## [`bitmap`](@ref)
 ```@example
+using Main: SVGJSWritable #hide
 using Compose
 set_default_graphic_size(14cm,4cm)
 rawimg = read(joinpath(@__DIR__,"..","assets/smiley.png"));
@@ -34,6 +35,7 @@ img = compose(context(),
     (context(), rectangle(), fill("transparent"), stroke("orange")),
     (context(), bitmap(["image/png"], [rawimg], X[:,1], X[:,2], [0.1], [0.1]))
 )
+SVGJSWritable(ans) #hide
 ```
 
 ## [`circle`](@ref)


### PR DESCRIPTION
thanks to @mortenpi for the `SVGJSWriteable` trick!  necessary here because Cairo does not support bitmaps.