### PR TITLE
docstring for UnitBox

### DIFF
--- a/src/container.jl
+++ b/src/container.jl
@@ -87,6 +87,7 @@ Create a node in the tree structure that defines a graphic.  Use
 [`Rotation`](@ref), [`Mirror`](@ref), and [`Shear`](@ref).
 
 # Arguments
+- `units`: the coordinate system for the context, defined by a [`UnitBox`](@ref).
 - `order`: the Z-order of this context relative to its siblings.
 - `clip`:  clip children of the canvas by its bounding box if true.
 - `withjs`: ignore this context and everything under it if we are not drawing to the SVGJS backend.

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -120,15 +120,28 @@ struct UnitBox{S,T,U,V}
     bottompad::AbsoluteLength
 end
 
+"""
+    UnitBox(x0, y0, width, height; leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm)
+
+Specifies the coordinate system for a [`context`](@ref), with origin `x0`, `y0`, plus `width`, `height`.
+"""
 UnitBox(x0, y0, width, height; leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm) =
         UnitBox{typeof(x0), typeof(y0), typeof(width), typeof(height)}(
             x0, y0, width, height, leftpad, rightpad, toppad, bottompad)
 
+"""
+    UnitBox(width, height; leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm)
+
+Specifies the coordinate system for a [`context`](@ref), with origin `0, 0` plus `width`, `height`.
+"""
 function UnitBox(width, height; leftpad=0mm, rightpad=0mm, toppad=0mm, bottompad=0mm)
     S, T = typeof(width), typeof(height)
     UnitBox{S,T,S,T}(zero(S), zero(T), width, height, leftpad, rightpad, toppad, bottompad)
 end
 
+"""
+    UnitBox() = UnitBox(0.0, 0.0, 1.0, 1.0)
+"""
 UnitBox() = UnitBox(0.0, 0.0, 1.0, 1.0)
 
 # copy with substitution


### PR DESCRIPTION
- [x] I've built the docs and confirmed these changes don't cause new errors

### This PR

- adds docstrings for `UnitBox` (mentioned in #335)
- Note there is already an example of `UnitBox` in the [Tutorial](https://giovineitalia.github.io/Compose.jl/latest/tutorial/#Contexts-specify-a-coordinate-system-for-their-children-1)
