### PR TITLE
Bezigon Primitive

### DIFF
--- a/docs/src/gallery/forms.md
+++ b/docs/src/gallery/forms.md
@@ -23,6 +23,20 @@ img2 = compose(context(),
 hstack(img1, img2)
 ```
 
+## [`bezigon`](@ref)
+ 
+```@example
+using Colors, Compose
+set_default_graphic_size(14cm,10cm)
+
+petal = [[(0.4, 0.4), (0.4, 0.2), (0.5, 0.0)],  [(0.6, 0.2), (0.6, 0.4), (0.5, 0.5)]]
+petalf(θ::Float64) = (context(rotation=Rotation(θ, 0.5,0.5)),
+    bezigon((0.5, 0.5), petal), fill(LCHuvA(70.,50., 360*θ/2π, 0.4)))
+
+theta = range(π/20, 2π, step=2π/10).-π
+img = compose(context(), petalf.(theta)...)
+```
+
 ## [`bitmap`](@ref)
 ```@example
 using Main: SVGJSWritable #hide

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -18,7 +18,7 @@ import Measures: resolve, w, h
 export compose, compose!, Context, UnitBox, AbsoluteBoundingBox,
         Rotation, Mirror, Shear,
        ParentDrawContext, context, ctxpromise, table, set_units!, minwidth, minheight,
-       text_extents, max_text_extents, polygon, ngon, star, xgon,
+       text_extents, max_text_extents, polygon, ngon, star, xgon, bezigon,
        line, rectangle, circle, arc, sector, ellipse, text, curve, bitmap, 
        stroke, fill, strokedash, strokelinecap, arrow, strokelinejoin,
        linewidth, visible, fillopacity, strokeopacity, clip, points,

--- a/src/cairo_backends.jl
+++ b/src/cairo_backends.jl
@@ -853,5 +853,29 @@ function arrowhead(img::Image, point::Vec, vl::Float64, θ::Float64)
 end
 
 
+# Bezigon
+
+
+
+function draw(img::Image, prim::BezierPolygonPrimitive)
+    move_to(img, prim.anchor)
+    currentpoint = prim.anchor
+    for side in prim.sides
+        if length(side)==1
+            line_to(img, side[1])
+        elseif length(side)==2
+            cp1 = controlpnt(currentpoint, side[1])
+            cp2 = controlpnt(side[2], side[1])
+            curve_to(img, cp1, cp2, side[2])
+        elseif length(side)==3
+            curve_to(img, side[1], side[2], side[3])
+        end
+        currentpoint = side[end]
+    end
+    close_path(img)
+    fillstroke(img)
+end
+
+
 
 

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -383,3 +383,7 @@ end
 
 resolve(box::AbsoluteBox, units::UnitBox, t::Transform, a::Shear) =
             Shear(a.shear, a.theta, resolve(box, units, t, a.point))
+
+
+# for transforming quadratic to cubic  
+controlpnt(anchor::XYTupleOrVec, control::XYTupleOrVec) = 0.333*anchor + 0.667*control

--- a/src/misc.jl
+++ b/src/misc.jl
@@ -212,3 +212,4 @@ end
 *(a::Dates.Day, b::AbstractFloat) = b * a
 *(a::AbstractFloat, b::Dates.Millisecond) = Dates.Millisecond(round(Int64, (a * b.value)))
 *(a::Dates.Millisecond, b::AbstractFloat) = b * a
+

--- a/src/pgf_backend.jl
+++ b/src/pgf_backend.jl
@@ -632,3 +632,34 @@ function draw(img::PGF, prim::ArcPrimitive, idx::Int)
     write(img.buf, ";\n")
 end
 
+
+function draw(img::PGF, prim::BezierPolygonPrimitive, idx::Int)
+    modifiers, props = get_vector_properties(img, idx)
+    img.visible || return
+    write(img.buf, join(modifiers))
+    @printf(img.buf, "\\path [%s] ", join(props, ","))
+    @printf(img.buf, "(%s,%s)", svg_fmt_float(prim.anchor[1].value),
+        svg_fmt_float(prim.anchor[2].value))
+    currentpoint = prim.anchor
+    for side in prim.sides
+        if length(side)==1
+            point = side[1]
+            @printf(img.buf, " -- (%s,%s)", svg_fmt_float(point[1].value),
+                svg_fmt_float(point[2].value))
+        else
+        cp1, cp2, ep = if length(side)==2
+                controlpnt(currentpoint, side[1]),
+                controlpnt(side[2], side[1]), side[2]
+            elseif length(side)==3
+                side[1], side[2], side[3]
+            end
+            @printf(img.buf, " .. controls (%s,%s) and (%s,%s) .. (%s,%s)",
+            svg_fmt_float(cp1[1].value), svg_fmt_float(cp1[2].value),
+            svg_fmt_float(cp2[1].value), svg_fmt_float(cp2[2].value),
+            svg_fmt_float(ep[1].value), svg_fmt_float(ep[2].value))
+        end
+        currentpoint = side[end]
+    end
+    write(img.buf, " -- cycle;\n")
+end
+

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -1291,3 +1291,52 @@ function svgalphatest(properties::Vector{Property})
 end
 
 
+function draw(img::SVG, prim::BezierPolygonPrimitive, idx::Int)
+
+    points = [prim.anchor; reduce(vcat, prim.sides)]
+    x0 = sum(first.(points))/length(points)
+    y0 = sum(last.(points))/length(points)
+
+    sv = Vector{Vec}[]
+    for side in prim.sides
+        s = collect(Tuple{Measure, Measure}, zip(first.(side).-x0, last.(side).-y0))
+        push!(sv, s)
+    end
+    anchor0 = (prim.anchor[1]-x0, prim.anchor[2]-y0)
+
+    P = Dict(1=>" L", 2=>" Q", 3=>" C")
+    indent(img)
+
+    img.indentation += 1
+    print(img.out, "<g transform=\"translate(")
+    svg_print_float(img.out, x0.value)
+    print(img.out, ",")
+    svg_print_float(img.out, y0.value)
+    print(img.out, ")\"")
+    print_vector_properties(img, idx, true)
+    print(img.out, ">\n")
+    indent(img)
+
+    print(img.out, "<path d=\"M")
+    svg_print_float(img.out, anchor0[1].value)
+    print(img.out, ",")
+    svg_print_float(img.out, anchor0[2].value)
+
+    for side in sv
+        print(img.out, P[length(side)])
+            for point in side
+                svg_print_float(img.out, point[1].value)
+                print(img.out, ',')
+                svg_print_float(img.out, point[2].value)
+                print(img.out, ' ')
+            end
+    end
+
+    print(img.out, "z\"")
+    print(img.out, " class=\"primitive\"")
+    print(img.out, "/>\n")
+
+    img.indentation -= 1
+    indent(img)
+    print(img.out, "</g>\n")
+end

--- a/test/examples/bezigon.jl
+++ b/test/examples/bezigon.jl
@@ -1,0 +1,22 @@
+
+import Cairo
+using Compose
+set_default_graphic_size(6.6inch, 3.3inch)
+
+# See Picasso's "dog" sketch
+dog = [[(183, 268), (186, 256), (189, 244)], [(290, 244), (300, 230), (339, 245)], [(350,290), (360, 300), (355, 210)], 
+[(370, 207), (380,196), (375, 193)], [(310, 220), (190, 220), (164, 205)], [(135, 194), (135, 265), (153, 275)],
+[(168, 275), (170, 180), (150, 190)], [(122, 214), (142, 204), (85, 240)], [(100, 247), (125, 233), (140, 238)]]
+
+
+ub = UnitBox(0,0, 500,500)
+p = compose(context(), stroke("black"), fillopacity(0.1),
+    (context(0,0, 0.5,1, units=ub,  rotation=Rotation(-π/8)), bezigon((180, 280), dog)),
+    (context(0.5,0, 0.5,1, units=ub, rotation=Rotation(π/8)),  bezigon([(180, 280)], [dog]))
+)
+
+
+imgs = [SVG("bezigon.svg"), PNG("bezigon.png")]
+
+draw.(imgs, [p])
+


### PR DESCRIPTION
- [x] I've updated the documentation to reflect these changes
- [x] I've built the docs and confirmed these changes don't cause new errors
- [x] I've added and/or updated the unit tests
- [x] I've run the regression tests

### This PR
- adds a [bezigon](https://en.wikipedia.org/wiki/Composite_B%C3%A9zier_curve) form
- Suggested in https://github.com/GiovineItalia/Compose.jl/pull/298#issuecomment-531218947

## To do

- [x] Implement `bezigon` for the PGF backend.
- [x] Support quadratic beziers by transforming to cubic (for Cairo)

## Example

```julia
petal = [[(0.4, 0.4), (0.4, 0.2), (0.5, 0.0)],  [(0.6, 0.2), (0.6, 0.4), (0.5, 0.5)]]
petalf(θ::Float64) =    (context(rotation=Rotation(θ, 0.5,0.5)),
    bezigon((0.5, 0.5), petal), fill(LCHuvA(70.,50., 360*θ/2π, 0.4)) )

 theta = range(π/20, 2π, step=2π/10) .-π
 compose(context(), petalf.(theta)...)
```
![petals](https://user-images.githubusercontent.com/18226881/71764538-1d576a00-2f3d-11ea-90c9-99f60a71bbbc.png)

