### PR TITLE
fix pango bug with unicode text

### DIFF
--- a/src/pango.jl
+++ b/src/pango.jl
@@ -333,7 +333,7 @@ function pango_to_svg(text::AbstractString)
 
     # TODO: do c_stripped_text and c_attr_list need to be freed?
 
-    text = unsafe_string(c_stripped_text[])
+    text = codeunits(unsafe_string(c_stripped_text[]))
 
     last_idx = 1
     open_tag = false

--- a/test/examples/text.jl
+++ b/test/examples/text.jl
@@ -5,5 +5,8 @@
 using Compose
 
 img = PNG("text.png", 400px, 400px)
-c = compose(compose(context(), text(150px, 200px, "hello &amp; goodbye")), fill("tomato"))
+c = compose(compose(context(),
+                    text(150px, 200px,
+                         "hello &amp; goodbye\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>")),
+            fill("tomato"))
 draw(img, c)


### PR DESCRIPTION
fixes this error:

```
julia> title_string
"A<sub>α</sub>=1.2, &#964;<sub>α,on</sub>=530.0, &#964;<sub>α,off</sub>=16.0,A<sub>e,on</sub>=0.026, &#964;<sub>e,on</sub>=37.0,A<sub>e,off</sub>=0.022, &#964;<sub>e,off</sub>=1.8\ndF/F0<sub>transient</sub>=0.026, dF/F0<sub>plateau,on</sub>=0.026, dF/F0<sub>plateau,off</sub>=0.022, T<sub>on,transient</sub>=NaN, T<sub>off,transient</sub>=0.0015, T<sub>off,plateau</sub>=3.9\nblch=0.0042, SNR=7"

julia> Compose.pango_to_svg(title_string)
ERROR: StringIndexError("Aα=1.2, τα,on=530.0, τα,off=16.0,Ae,on=0.026, τe,on=37.0,Ae,off=0.022, τe,off=1.8\ndF/F0transient=0.026, dF/F0plateau,on=0.026, dF/F0plateau,off=0.022, Ton,transient=NaN, Toff,transient=0.0015, Toff,plateau=3.9\nblch=0.0042, SNR=7", 3)
Stacktrace:
 [1] string_index_err(::String, ::Int64) at ./strings/string.jl:12
 [2] getindex(::String, ::UnitRange{Int64}) at ./strings/string.jl:250
 [3] (::Compose.var"#155#156"{Base.RefValue{Ptr{Nothing}}})(::Base.GenericIOBuffer{Array{UInt8,1}}) at /groups/scicompsoft/home/arthurb/.julia/dev/Compose/src/pango.jl:344
 [4] sprint(::Function; context::Nothing, sizehint::Int64) at ./strings/io.jl:105
 [5] sprint at ./strings/io.jl:101 [inlined]
 [6] pango_to_svg(::String) at /groups/scicompsoft/home/arthurb/.julia/dev/Compose/src/pango.jl:342
 [7] top-level scope at REPL[217]:1
```