### PR TITLE
fix line spacing for sub/superscripts

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -86,17 +86,6 @@ end
 svg_fmt_color(c::Color) = string("#", hex(c))
 svg_fmt_color(c::Nothing) = "none"
 
-# Replace newlines in a string with the appropriate SVG tspan tags.
-function svg_newlines(input::AbstractString)
-    output = IOBuffer()
-    inputs = split(input,"\n")
-    write(output, inputs[1])
-    for mat in inputs[2:end]
-        write(output, """<tspan x="0" dy="1.2em">""", mat, "</tspan>")
-    end
-    return String(take!(output))
-end
-
 # Javascript in a <script> tag in SVG needs to escape '"' and '<'.
 #=function escape_script(js::AbstractString)=#
     #=return replace(replace(js, "&", "&amp;"), "<", "&lt;")=#
@@ -1006,8 +995,7 @@ function draw(img::SVG, prim::TextPrimitive, idx::Int)
         print(img.out, "\"")
     end
 
-    @printf(img.out, ">%s</text>\n",
-            svg_newlines(pango_to_svg(prim.value)))
+    @printf(img.out, ">%s</text>\n", pango_to_svg(prim.value))
 
     img.indentation -= 1
     indent(img)

--- a/test/examples/arc_sector.jl
+++ b/test/examples/arc_sector.jl
@@ -1,9 +1,8 @@
-
 using Compose
-
+import Cairo, Fontconfig
 
 imgs = [SVG("arc_sector.svg", 7cm, 7cm),
-    PDF("arc_sector.pdf", 7cm, 7cm)]
+        PDF("arc_sector.pdf", 7cm, 7cm)]
 
 a = range(-0.5π, stop=1.5π, length=13)
     colv = repeat(["white","black"], outer=6)

--- a/test/examples/arrow.jl
+++ b/test/examples/arrow.jl
@@ -1,8 +1,8 @@
-
 using Compose
+import Cairo, Fontconfig
 
 imgs = [SVG("arrow.svg", 5cm, 5cm),
-PDF("arrow.pdf", 5cm, 5cm)]
+        PDF("arrow.pdf", 5cm, 5cm)]
 
 X =  [0.047 0.87 0.95 0.93;
 0.22 0.01 0.21 0.7;

--- a/test/examples/bezigon.jl
+++ b/test/examples/bezigon.jl
@@ -1,6 +1,6 @@
-
-import Cairo
 using Compose
+import Cairo, Fontconfig
+
 set_default_graphic_size(6.6inch, 3.3inch)
 
 # See Picasso's "dog" sketch
@@ -14,7 +14,6 @@ p = compose(context(), stroke("black"), fillopacity(0.1),
     (context(0,0, 0.5,1, units=ub,  rotation=Rotation(-π/8)), bezigon((180, 280), dog)),
     (context(0.5,0, 0.5,1, units=ub, rotation=Rotation(π/8)),  bezigon([(180, 280)], [dog]))
 )
-
 
 imgs = [SVG("bezigon.svg"), PNG("bezigon.png")]
 

--- a/test/examples/dashedlines.jl
+++ b/test/examples/dashedlines.jl
@@ -1,9 +1,7 @@
-#!/usr/bin/env julia
-
 # Draw lines with various dash styles.
 
-using Compose
-using Colors
+using Compose, Colors
+import Cairo, Fontconfig
 
 function draw_lines(dash_patterns)
     if length(dash_patterns) == 0

--- a/test/examples/golden_rect.jl
+++ b/test/examples/golden_rect.jl
@@ -1,7 +1,4 @@
-#!/usr/bin/env julia
-
-using Colors
-using Compose
+using Compose, Colors
 using Base.MathConstants
 
 function golden_rect(n::Int)
@@ -12,4 +9,4 @@ function golden_rect(n::Int)
 end
 
 draw(SVG("golden_rect.svg", φ*3inch, 3inch),
-    compose(golden_rect(8), linewidth(0.2mm)))
+     compose(golden_rect(8), linewidth(0.2mm)))

--- a/test/examples/linecaps.jl
+++ b/test/examples/linecaps.jl
@@ -1,9 +1,7 @@
-#!/usr/bin/env julia
-
 # Draw lines with various dash styles.
 
-using Compose
-using Colors
+using Compose, Colors
+import Cairo, Fontconfig
 
 function draw_lines(caps)
     if length(caps) == 0

--- a/test/examples/linejoins.jl
+++ b/test/examples/linejoins.jl
@@ -1,9 +1,7 @@
-#!/usr/bin/env julia
-
 # Draw lines with various dash styles.
 
-using Compose
-using Colors
+using Compose, Colors
+import Cairo, Fontconfig
 
 function draw_lines(joins)
     if length(joins) == 0

--- a/test/examples/polygon_forms.jl
+++ b/test/examples/polygon_forms.jl
@@ -1,4 +1,3 @@
-
 using Compose
 
 compose(context(),

--- a/test/examples/primitives.jl
+++ b/test/examples/primitives.jl
@@ -1,5 +1,3 @@
-#!/usr/bin/env julia
-
 using Compose
 
 rawimg = read(joinpath(@__DIR__,"smiley.png"));

--- a/test/examples/text.jl
+++ b/test/examples/text.jl
@@ -1,8 +1,7 @@
-#!/usr/bin/env julia
-
 # Draw some text to a PNG image.
 
 using Compose
+import Cairo, Fontconfig
 
 img = PNG("text.png", 400px, 400px)
 c = compose(compose(context(),

--- a/test/examples/text.jl
+++ b/test/examples/text.jl
@@ -1,11 +1,15 @@
 # Draw some text to a PNG image.
 
 using Compose
+
+lines = "hello and goodbye\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>\nA Third Line\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>Pooh\nA Fifth Line\nA Sixth Line"
+c = compose(context(),
+            (context(), text(0px, 250px, lines), fontsize(8pt), fill("tomato")),
+            (context(), text(100px, 250px, lines), fontsize(24pt), fill("bisque")))
+draw(SVG("text-fontfallback.svg", 400px, 400px), c)
+
 import Cairo, Fontconfig
 
-img = PNG("text.png", 400px, 400px)
-c = compose(compose(context(),
-                    text(150px, 200px,
-                         "hello &amp; goodbye\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>")),
-            fill("tomato"))
-draw(img, c)
+draw(SVG("text-pango.svg", 400px, 400px), c)
+draw(PNG("text.png", 400px, 400px, dpi=192), c)
+draw(PDF("text.pdf", 400px, 400px), c)

--- a/test/examples/transformations.jl
+++ b/test/examples/transformations.jl
@@ -1,8 +1,8 @@
-
 using Compose
+import Cairo, Fontconfig
 
 imgs = [SVG("transformations.svg", 7cm, 7cm),
-PDF("transformations.pdf", 7cm, 7cm)]
+        PDF("transformations.pdf", 7cm, 7cm)]
 
 
 img = compose(context(),

--- a/test/examples/unicode.jl
+++ b/test/examples/unicode.jl
@@ -1,5 +1,3 @@
-#!/usr/bin/env julia
-
 # Draw some unicodes to an image.
 # https://github.com/GiovineItalia/Compose.jl/pull/360#issuecomment-539283765
 

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -1,5 +1,4 @@
-using Test, Random
-using Colors
+using Compose, Test, Random, Colors
 
 # must be before importing cairo
 @testset "missing cairo errors" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,28 +1,14 @@
-using Compose
 using Test
 
 include("misc.jl")
-@testset "SVG Correctness Tests" begin
-    include("svg.jl")
-end
+include("svg.jl")
 include("immerse.jl")
 
 # Run the examples
 cd(joinpath(@__DIR__, "output"))
-
 exampledir = joinpath(@__DIR__, "examples")
 for ex in readdir(exampledir)
     endswith(ex, ".jl") || continue
     file = joinpath(exampledir, ex)
-    expr = quote
-        module $(Symbol(replace(ex, "."=>"_")))
-        using Compose
-        using Colors
-        using Random
-        Random.seed!(1) #Needed so that SVG uuid is reproducible
-        include($file)
-        end
-    end
-    expr.head = :toplevel
-    eval(expr)
+    run(`$(Base.julia_cmd()) --startup-file=no $file`)
 end

--- a/test/svg.jl
+++ b/test/svg.jl
@@ -1,3 +1,4 @@
+using Compose
 using Test
 using EzXML
 using Colors


### PR DESCRIPTION
fixes this problem:

```
julia> using Compose
[ Info: Precompiling Compose [a81c6b42-2e10-5240-aca2-a61377ecd94b]

julia> img = SVG("text.svg", 400px, 400px)
SVG(105.82010582010584mm, 105.82010582010584mm, IOStream(<file text.svg>), nothing, "img-a0c68168", 0, Compose.SVGPropertyFrame[], Dict{Type,Union{Nothing, Compose.Property}}(), OrderedCollections.OrderedDict{Compose.ClipPrimitive,String}(), Tuple{Compose.FormPrimitive,String}[], Set(AbstractString[]), false, true, "text.svg", true, "", false, 0, Set(AbstractString[]), Set(Tuple{AbstractString,AbstractString}[("Snap.svg", "Snap")]), AbstractString[], false, :none, ())

julia> c = compose(compose(context(),
                                  text(150px, 200px,
                                       "hello &amp; goodbye\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>\nA Third Line\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>Pooh\nAFourth Line\nA Fifth Line")),
                          fill("tomato"))
Context(Measures.BoundingBox{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}},Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}}((0.0w, 0.0h), (1.0w, 1.0h)), nothing, nothing, nothing, nothing, List([]), List([Compose.Form{Compose.TextPrimitive{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},Rotation{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}},Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}}}}(Compose.TextPrimitive{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},Rotation{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}},Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}}}[Compose.TextPrimitive{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},Rotation{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}},Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}}}((39.68253968253969mm, 52.91005291005292mm), "hello &amp; goodbye\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>\nA Third Line\nFoo<sub>Sub</sub>Bar<sup>Sup</sup>Pooh\nAFourth Line\nA Fifth Line", Compose.HLeft(), Compose.VBottom(), Rotation{Tuple{Measures.Length{:w,Float64},Measures.Length{:h,Float64}}}(0.0, (0.5w, 0.5h)), (0.0mm, 0.0mm))], Symbol(""))]), List([Compose.Property{Compose.FillPrimitive}(Compose.FillPrimitive[Compose.FillPrimitive(RGBA{Float64}(1.0,0.38823529411764707,0.2784313725490196,1.0))])]), 0, false, false, false, false, nothing, nothing, 0.0, Symbol(""))

julia> draw(img, c)
false
```

<img width="168" alt="Screen Shot 2020-03-24 at 8 40 36 PM" src="https://user-images.githubusercontent.com/1538268/77489898-cbbdcd80-6e0f-11ea-9e20-4eeed071bff2.png">
