### PR TITLE
Fix incorrect length of UTF-8 string for pango layout

### DIFF
--- a/src/pango.jl
+++ b/src/pango.jl
@@ -80,7 +80,7 @@ end
 #   A (width, height) tuple in absolute units.
 #
 function pango_text_extents(pangolayout::PangoLayout, text::AbstractString)
-    textarray = convert(String, text)
+    textarray = codeunits(text)
     ccall((:pango_layout_set_markup, libpango),
           Cvoid, (Ptr{Cvoid}, Ptr{UInt8}, Int32),
           pangolayout.layout, textarray, length(textarray))

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -140,6 +140,13 @@ import Fontconfig
     @test Compose.pango_to_pgf("hello\\") == "\\text{hello\\textbackslash{}}"
 end
 
+@testset "pango utf-8 text_extents" begin
+    @test @isdefined Fontconfig
+    w1 = Compose.text_extents("", 8pt, "α")[1]
+    w2 = Compose.text_extents("", 8pt, "αα")[1]
+    @test w1 < w2
+end
+
 @testset "table" begin
     @testset "force aspect ratio" begin
         tbl = Compose.Table(1, 1, UnitRange(1,1), UnitRange(3:3), aspect_ratio=1.6);


### PR DESCRIPTION
I believe this is also related to GiovineItalia/Gadfly.jl#1410.

```julia
julia> using Compose
julia> import Cairo, Fontconfig
```

before
```julia
julia> Compose.text_extents("", 8pt, "α")

(process:35143): Pango-WARNING **: 21:27:47.868: pango_layout_set_markup_with_accel: Error on line 1 char 10: Invalid UTF-8 encoded text in name — not valid “\xce”
1-element Array{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},1}:
 (1.5075737847222221mm, 1.522732204861111mm)

julia> Compose.text_extents("", 8pt, "αα")
1-element Array{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},1}:
 (1.5075737847222221mm, 1.522732204861111mm)
```

Note that the first case complained about a clipped string array, but still got a correct width. The length of UTF-8 string array for `"α"` supposed to be 2 (`"\xce\xb1"`), but `pango_text_extents` internally used a length of Julia String which was 1 for this.

The second case seemed working fine with no complaints, but due to spurious string length, only the first letter was accounted for layout. That's why we had same widths for them which are not we'd expect.

after
```julia
julia> Compose.text_extents("", 8pt, "α")
1-element Array{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},1}:
 (1.5075737847222221mm, 1.522732204861111mm)

julia> Compose.text_extents("", 8pt, "αα")
1-element Array{Tuple{Measures.Length{:mm,Float64},Measures.Length{:mm,Float64}},1}:
 (3.231499565972222mm, 1.522732204861111mm)
```

Now we no longer have pango warning and get correct widths for the both cases.