### PR TITLE
Fix handling of non-UTF-8 string length for pango layout

### DIFF
--- a/src/pango.jl
+++ b/src/pango.jl
@@ -80,10 +80,10 @@ end
 #   A (width, height) tuple in absolute units.
 #
 function pango_text_extents(pangolayout::PangoLayout, text::AbstractString)
-    textarray = codeunits(text)
+    textarray = convert(String, text)
     ccall((:pango_layout_set_markup, libpango),
           Cvoid, (Ptr{Cvoid}, Ptr{UInt8}, Int32),
-          pangolayout.layout, textarray, length(textarray))
+          pangolayout.layout, textarray, sizeof(textarray))
 
     extents = Array{Int32}(undef, 4)
     ccall((:pango_layout_get_extents, libpango),


### PR DESCRIPTION
Fix for #393 as suggested by @ScottPJones.

Specific test cases for non-UTF-8 string would require import some external deps like [LegacyStrings.jl](https://github.com/JuliaStrings/LegacyStrings.jl) or [Strs.jl](https://github.com/JuliaString/Strs.jl) thus has not been made into this commit. The originally intended fix for UTF-8 unicode strings could be still picked up by a test case implemented in #393.