### PR TITLE
Missing and NaN support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ Measures = "442fdcdd-2543-5da2-b0f3-8c86c306513e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Requires = "ae029012-a4dd-5104-9daa-d747884805df"
+Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]

--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -8,6 +8,7 @@ using Requires
 using Dates
 using Printf
 using Base.Iterators
+using Statistics
 import JSON
 
 import Base: length, isempty, getindex, setindex!,

--- a/src/measure.jl
+++ b/src/measure.jl
@@ -55,6 +55,8 @@ y_measure(a::Vector) = Measure[y_measure(y) for y in a]
 size_measure(a::Measure) = a
 size_measure(a) = a * mm
 
+x_measure(a::Missing) = x_measure(NaN)
+y_measure(a::Missing) = y_measure(NaN)
 
 # Higher-order measures
 # ---------------------

--- a/test/examples/forms_and_nans.jl
+++ b/test/examples/forms_and_nans.jl
@@ -1,0 +1,22 @@
+using Compose
+import Cairo, Fontconfig
+
+set_default_graphic_size(14cm, 10cm)
+
+
+y = [0.26, 0.5, missing, 0.4, NaN, 0.48, 0.58, 0.83]
+p1 = collect(Tuple, zip(1:8, y))
+p2 = collect(Tuple, zip(1:9, vcat(NaN, y)))
+
+img = compose(context(units=UnitBox(0, 0, 10, 1)),
+    (context(), line([p1]), stroke("black")),
+    (context(), line([p2]), stroke("red"))
+)
+
+imgs = [SVG("forms_and_nans.svg"), PDF("forms_and_nans.pdf")]
+
+draw.(imgs, [img])
+
+
+
+

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -184,3 +184,8 @@ end
     @test occursin("fill-opacity=\"0.3\"", String(img2.out.data))
     @test img3.fill_opacity == 0.3
 end
+
+@testset "Missing" begin
+    @test Compose.x_measure(missing)===NaN*cx
+    @test Compose.y_measure(missing)===NaN*cy
+end


### PR DESCRIPTION
### This PR
- For lines with missing or NaN, makes SVG images consistent with Cairo
- fixes #384

### Example

```julia
y = [0.26, 0.5, missing, 0.4, NaN, 0.48, 0.58, 0.83]
p1 = collect(Tuple, zip(1:8, y))
p2 = collect(Tuple, zip(1:9, vcat(NaN, y)))

p = compose(context(units=UnitBox(0,0, 10, 1)), 
    (context(), rectangle(), fill(nothing), stroke("gray")),
    (context(), line([p1]), stroke("black")),
    (context(), line([p2]), stroke("red"))  
)
# draw(SVG(), p) # SVG and PNG look the same
draw(PNG(), p)
```
![forms_and_nans](https://user-images.githubusercontent.com/18226881/84560759-3a188900-ad8a-11ea-9bd3-8ef818c0ce8a.png)

