### PR TITLE
Update typo in docs for `text` function in form.jl

### DIFF
--- a/src/form.jl
+++ b/src/form.jl
@@ -390,7 +390,7 @@ Draw the text `value` at the position (`x`,`y`) relative to the current context.
 
 The default alignment of the text is `hleft` `vbottom`. The vertical and horizontal
 alignment is specified by passing `hleft`, `hcenter` or `hright` and `vtop`,
-`vcenter` or `vbottom` as values for `halgin` and `valgin` respectively.
+`vcenter` or `vbottom` as values for `halign` and `valign` respectively.
 """
 function text(x, y, value,
               halign::HAlignment=hleft, valign::VAlignment=vbottom,


### PR DESCRIPTION
fixed a typo I stumbled across while using Pluto