### PR TITLE
new mathjax support, requires JS

### DIFF
--- a/src/Compose.jl
+++ b/src/Compose.jl
@@ -28,7 +28,8 @@ export compose, compose!, Context, UnitBox, AbsoluteBoundingBox,
        vbottom, SVG, SVGJS, PGF, PNG, PS, PDF, draw, pad, pad_inner, pad_outer,
        hstack, vstack, gridstack, LineCapButt, LineCapSquare, LineCapRound,
        CAIROSURFACE, introspect, set_default_graphic_size, set_default_jsmode,
-       boundingbox, Patchable
+       boundingbox, Patchable,
+       rawsvg, mathjax
 
 abstract type Backend end
 

--- a/src/svg.jl
+++ b/src/svg.jl
@@ -982,6 +982,13 @@ function draw(img::SVG, prim::TextPrimitive, idx::Int)
     print(img.out, "</g>\n")
 end
 
+function draw(img::SVG, prim::RawSVGPrimitive, idx::Int)
+    indent(img)
+    img.indentation += 1
+    print(img.out, prim.value)
+    img.indentation -= 1
+end
+
 function draw(img::SVG, prim::CurvePrimitive, idx::Int)
     x0, y0 = prim.anchor0[1], prim.anchor0[2]
     x0, y0 += prim.ctrl0[1], prim.ctrl0[2]
@@ -1305,3 +1312,58 @@ function draw(img::SVG, prim::BezierPolygonPrimitive, idx::Int)
     indent(img)
     print(img.out, "</g>\n")
 end
+
+function draw(img::SVG, prim::MathJaxPrimitive, idx::Int)
+    indent(img)
+
+    img.indentation += 1
+    print(img.out, "<g transform=\"translate(")
+    svg_print_float(img.out, prim.position[1].value)
+    print(img.out, ",")
+    svg_print_float(img.out, prim.position[2].value)
+    print(img.out, ")\"")
+    print_vector_properties(img, idx, true)
+    print(img.out, ">\n")
+    indent(img)
+
+    print(img.out, "<g class=\"primitive\">\n")
+    img.indentation += 1
+    indent(img)
+    print(img.out, """<foreignObject x="0" y="0" """)
+
+    if abs(prim.rot.theta) > 1e-4 || sum(abs.(prim.offset)) > 1e-4mm
+        print(img.out, " transform=\"")
+        if abs(prim.rot.theta) > 1e-4
+            print(img.out, "rotate(")
+            svg_print_float(img.out, rad2deg(prim.rot.theta))
+            print(img.out, ",")
+            svg_print_float(img.out, prim.rot.offset[1].value-prim.position[1].value)
+            print(img.out, ", ")
+            svg_print_float(img.out, prim.rot.offset[2].value-prim.position[2].value)
+            print(img.out, ")")
+        end
+        if sum(abs.(prim.offset)) > 1e-4mm
+            print(img.out, "translate(")
+            svg_print_float(img.out, prim.offset[1].value)
+            print(img.out, ",")
+            svg_print_float(img.out, prim.offset[2].value)
+            print(img.out, ")")
+        end
+        print(img.out, "\"")
+    end
+
+    print(img.out, """ width="$(prim.size[1])" height="$(prim.size[2])">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+    \\(\\displaystyle{$(prim.value)}\\)
+    </div>
+</foreignObject>""")
+
+    img.indentation -= 1
+    indent(img)
+    print(img.out, "</g>\n")
+    img.indentation -= 1
+    indent(img)
+    print(img.out, "</g>\n")
+end
+
+

--- a/test/examples/primitives.jl
+++ b/test/examples/primitives.jl
@@ -11,4 +11,11 @@ compose(context(),
         line([(0.1,0.3),(0.2,0.3)]),
         curve((0.25,0.35),(0.25,0.25),(0.35,0.25),(0.35,0.35))),
     bitmap("image/png",rawimg,0.4,0.25,0.1,0.1),
+    mathjax(0.2, 0.4, 0.1, 0.1, "x+1\\over y-1"),
+    rawsvg(raw"""<g xmlns="http://www.w3.org/2000/svg" transform="translate(84.85,30)">
+  <g class="primitive">
+    <text dy="-1em">hello</text>
+  </g>
+</g>"""),
+    bitmap("image/png",rawimg,0.4,0.25,0.1,0.1),
     text(0.6,0.3,"hello")) |> SVG("primitives.svg")

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -106,6 +106,15 @@ bm = bitmap("fake", rand(UInt8,10), 0, 1, 0.8, 0.7, :image)
 @test isa(Compose.text(0.5,0.4,"hello"), Compose.Text)
 @test isa(Compose.text(rand(5),rand(5),["hello","there"]), Compose.Text)
 
+@test isa(Compose.mathjax(0.5,0.4,0.1,0.2,raw"\frac{x}{2}"), Compose.MathJax)
+@test isa(Compose.mathjax(rand(2),rand(2),rand(2),rand(2),[raw"\frac{x}{2}",raw"\frac{x}{3}"]), Compose.MathJax)
+
+@test isa(Compose.rawsvg(raw"""<foreignObject x="50" y="50" width="100" height="100">
+    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family:Times; font-size:15px">
+		\(\displaystyle{x+1\over y-1}\)
+    </div>
+  </foreignObject>"""), Compose.RawSVG)
+
 @test isa(Compose.line(), Compose.Line)
 @test isa(Compose.line([(1,2),(3,5),(4,2)]), Compose.Line)
 


### PR DESCRIPTION
# List of changes
## MathJax support when rendering SVG in a browser

It works directly in Pluto notebooks.
```julia
compose(context(), mathjax(0.2, 0.2, 0.1, 0.1, "x+1\\over y-1"), fontsize(12pt))
```

![image](https://user-images.githubusercontent.com/6257240/108102246-4c07a580-7056-11eb-96e8-c49235e7872a.png)

If not using a Pluto notebook, one needs to add the following javascript in the HTML header
```html
<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_SVG"></script>
```

## Allowing inserting Raw SVG elements
I feel this provides flexibility to make an extension. Although most people do not need this. For example, the following code also renders the Mathjax
```julia
compose(context(), rawsvg(raw"""<foreignObject x="50" y="50" width="100" height="100">
    <div xmlns="http://www.w3.org/1999/xhtml" style="font-family:Times; font-size:15px">
		\(\displaystyle{x+1\over y-1}\)
    </div>
  </foreignObject>"""))
```

# Notes
**Please review this PR carefully because I am not quite familiar with Compose API.**

Reference:
https://stackoverflow.com/questions/15962325/mathjax-inside-svg#:~:text=Currently%2C%20the%20only%20way%20to,'t%20support%20.