### PR TITLE
Use the html tag for text/html

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -511,7 +511,12 @@ function show(io::IO, ::MIME"text/html", img::SVG)
     if img.cached_out === nothing
         img.cached_out = String(take!(img.out))
     end
-    write(io, img.cached_out)
+    write(io, 
+        """
+        <html>
+        $(img.cached_out)
+        </html>
+        """)
 end
 
 function show(io::IO, ::MIME"image/svg+xml", img::SVG)


### PR DESCRIPTION
Hi!

This fixes the interactivity of *Gadfly* plots on *Pluto*, solving the *Gadfly* example in https://github.com/fonsp/Pluto.jl/issues/546 and this [stackoverflow question](https://stackoverflow.com/questions/66297678/using-gadfly-interactively-in-pluto). The fix is similar to the one implemented in https://github.com/kimikage/ProfileSVG.jl/pull/50

**Before** (note that the plot don't react to the mouse)

![pluto_no](https://user-images.githubusercontent.com/2822757/125202393-b2929780-e273-11eb-8a0a-4462450f0265.png)

**After** (grid highlighted because of the interaction, also the question mark appears)

![pluto_si](https://user-images.githubusercontent.com/2822757/125202400-b7574b80-e273-11eb-8f52-9a8fe884d793.png)

This doesn't break **IJulia**

![ijulia_gadfly](https://user-images.githubusercontent.com/2822757/125202404-ba523c00-e273-11eb-98b8-beb562aab374.png)

nor the example in http://gadflyjl.org/stable/man/backends/#Interactive-SVGs

![doc_gadfly](https://user-images.githubusercontent.com/2822757/125202406-bd4d2c80-e273-11eb-8625-d2a3a07e29f6.png)

I hope this helps

Best,
 
