### PR TITLE
Revert "Use the html tag for text/html"

### DIFF
--- a/src/svg.jl
+++ b/src/svg.jl
@@ -511,12 +511,7 @@ function show(io::IO, ::MIME"text/html", img::SVG)
     if img.cached_out === nothing
         img.cached_out = String(take!(img.out))
     end
-    write(io, 
-        """
-        <html>
-        $(img.cached_out)
-        </html>
-        """)
+    write(io, img.cached_out)
 end
 
 function show(io::IO, ::MIME"image/svg+xml", img::SVG)


### PR DESCRIPTION
This reverts commit 3dbc5a020dbdf300cb0b1c059acbe443676181f1.

The commit was originally motivated by https://github.com/fonsp/Pluto.jl/issues/546 but the issues mentioned here have been solved in Pluto by now.

Using inline HTML instead of a full `<html>` document has much better performance, see https://github.com/JuliaPlots/Plots.jl/pull/3559 for more info

cc @diegozea 