### PR TITLE
Update Compat for Colors.jl to 0.13, bump patch version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Compose"
 uuid = "a81c6b42-2e10-5240-aca2-a61377ecd94b"
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
@@ -18,7 +18,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
-Colors = "0.9, 0.10, 0.11, 0.12"
+Colors = "0.9, 0.10, 0.11, 0.12, 0.13"
 DataStructures = "0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18"
 IterTools = "1"
 JSON = "0.18, 0.19, 0.20, 0.21"


### PR DESCRIPTION
Hello! A few of my packages depend on Compose and Colors. Can we update the compat for Colors to include 0.13? It appears to not break anything.